### PR TITLE
Ensure stak statements can be eval'd

### DIFF
--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -78,7 +78,6 @@ func SaveSession(filename string, config structs.Configuration) error {
 
 // PrintSTAK prints out the short term access keys for AWS auth.
 func PrintSTAK(stak kion.STAK, account string) error {
-	color.Green("Short-term Access Keys for %v:", account)
 	fmt.Printf("export AWS_ACCESS_KEY_ID=%v\n", stak.AccessKey)
 	fmt.Printf("export AWS_SECRET_ACCESS_KEY=%v\n", stak.SecretAccessKey)
 	fmt.Printf("export AWS_SESSION_TOKEN=%v\n", stak.SessionToken)


### PR DESCRIPTION
I should be able to use `eval $(kion fav -p sandbox)` in a script and get credentials.

This removes the comment so that the result can be evaled.