### PR TITLE
Ignore compiled kion binary at project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@ Thumbs.db
 # Repository Specific #
 #######################
 
-./kion
+/kion
 profile.cov
 tools/golangci-lint


### PR DESCRIPTION
Small correction to gitignore to exclude the compiled binary but not `lib/kion/*`.