### PR TITLE
Add workaround for users with min project permissions

### DIFF
--- a/lib/kion/account.go
+++ b/lib/kion/account.go
@@ -28,8 +28,6 @@ type Account struct {
 	Name                      string `json:"account_name"`
 	Number                    string `json:"account_number"`
 	TypeID                    uint   `json:"account_type_id"`
-	CreatedAt                 string `json:"created_at"`
-	DeletedAt                 string `json:"deleted_at"`
 	ID                        uint   `json:"id"`
 	IncludeLinkedAccountSpend bool   `json:"include_linked_account_spend"`
 	LinkedAccountNumber       string `json:"linked_account_number"`
@@ -37,30 +35,29 @@ type Account struct {
 	PayerID                   uint   `json:"payer_id"`
 	ProjectID                 uint   `json:"project_id"`
 	SkipAccessChecking        bool   `json:"skip_access_checking"`
-	StartDatecode             string `json:"start_datecode"`
 	UseOrgAccountInfo         bool   `json:"use_org_account_info"`
 }
 
 // GetAccountsOnProject returns a list of Accounts associated with a given Kion
 // project.
-func GetAccountsOnProject(host string, token string, id uint) ([]Account, error) {
+func GetAccountsOnProject(host string, token string, id uint) ([]Account, int, error) {
 	// build our query and get response
 	url := fmt.Sprintf("%v/api/v3/project/%v/accounts", host, id)
 	query := map[string]string{}
 	var data interface{}
-	resp, err := runQuery("GET", url, token, query, data)
+	resp, statusCode, err := runQuery("GET", url, token, query, data)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
 	// unmarshal response body
 	accResp := AccountsResponse{}
 	jsonErr := json.Unmarshal(resp, &accResp)
 	if jsonErr != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return accResp.Accounts, nil
+	return accResp.Accounts, accResp.Status, nil
 }
 
 // GetAccount returns an account by the given account number
@@ -69,7 +66,7 @@ func GetAccount(host string, token string, accountNum string) (*Account, error) 
 	url := fmt.Sprintf("%v/api/v3/account/by-account-number/%v", host, accountNum)
 	query := map[string]string{}
 	var data interface{}
-	resp, err := runQuery("GET", url, token, query, data)
+	resp, _, err := runQuery("GET", url, token, query, data)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/kion/auth.go
+++ b/lib/kion/auth.go
@@ -63,7 +63,7 @@ func GetIDMSs(host string) ([]IDMS, error) {
 	url := fmt.Sprintf("%v/api/v2/idms", host)
 	query := map[string]string{}
 	var data interface{}
-	resp, err := runQuery("GET", url, "", query, data)
+	resp, _, err := runQuery("GET", url, "", query, data)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func Authenticate(host string, idmsID uint, un string, pw string) (Session, erro
 		Username: un,
 		Password: pw,
 	}
-	resp, err := runQuery("POST", url, "", query, data)
+	resp, _, err := runQuery("POST", url, "", query, data)
 	if err != nil {
 		return Session{}, err
 	}

--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -55,7 +55,7 @@ func GetCARS(host string, token string) ([]CAR, error) {
 	url := fmt.Sprintf("%v/api/v3/me/cloud-access-role", host)
 	query := map[string]string{}
 	var data interface{}
-	resp, err := runQuery("GET", url, token, query, data)
+	resp, _, err := runQuery("GET", url, token, query, data)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/kion/console.go
+++ b/lib/kion/console.go
@@ -39,7 +39,7 @@ func GetFederationURL(host string, token string, car CAR) (string, error) {
 		RoleID:         0,
 		RoleType:       "",
 	}
-	resp, err := runQuery("POST", url, token, query, data)
+	resp, _, err := runQuery("POST", url, token, query, data)
 	if err != nil {
 		return "", err
 	}

--- a/lib/kion/kion.go
+++ b/lib/kion/kion.go
@@ -15,17 +15,17 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 // runQuery performs queries against the Kion API.
-func runQuery(method string, url string, token string, query map[string]string, payload interface{}) ([]byte, error) {
+func runQuery(method string, url string, token string, query map[string]string, payload interface{}) ([]byte, int, error) {
 	// prepare the request body
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// start our request
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(reqBody))
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// append on our parameters to the req.URL.String(), only active milestones
@@ -44,21 +44,21 @@ func runQuery(method string, url string, token string, query map[string]string, 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 
 	// get the body of the response
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// handle non 200's
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("received %v\n %v", resp.StatusCode, string(respBody))
+		return nil, resp.StatusCode, fmt.Errorf("received %v\n %v", resp.StatusCode, string(respBody))
 	}
 
 	// return the response
-	return respBody, nil
+	return respBody, resp.StatusCode, nil
 }

--- a/lib/kion/private.go
+++ b/lib/kion/private.go
@@ -1,0 +1,43 @@
+package kion
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ConsoleAccessResponse maps to the Kion V1 API response.
+type ConsoleAccessCARResponse struct {
+	Status            int                `json:"status"`
+	ConsoleAccessCARs []ConsoleAccessCAR `json:"data"`
+}
+
+// Account maps to the Kion API response for account data.
+type ConsoleAccessCAR struct {
+	CARName       string    `json:"name"`
+	CARID         int       `json:"id"`
+	CARRoleType   string    `json:"role_type"`
+	Accounts      []Account `json:"accounts"`
+	ConsoleAccess bool      `json:"console_access"`
+	STAKAccess    bool      `json:"short_term_key_access"`
+	LTAKAccess    bool      `json:"long_term_key_access"`
+}
+
+func GetConsoleAccessCARS(host string, token string, projID uint) ([]ConsoleAccessCAR, error) {
+	// build our query and get response
+	url := fmt.Sprintf("%v/api/v1/project/%v/console-access", host, projID)
+	query := map[string]string{}
+	var data interface{}
+	resp, _, err := runQuery("GET", url, token, query, data)
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal response body
+	consoleAccessCarResp := ConsoleAccessCARResponse{}
+	err = json.Unmarshal(resp, &consoleAccessCarResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return consoleAccessCarResp.ConsoleAccessCARs, nil
+}

--- a/lib/kion/project.go
+++ b/lib/kion/project.go
@@ -33,7 +33,7 @@ func GetProjects(host string, token string) ([]Project, error) {
 	url := host + "/api/v3/project"
 	query := map[string]string{}
 	var data interface{}
-	resp, err := runQuery("GET", url, token, query, data)
+	resp, _, err := runQuery("GET", url, token, query, data)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/kion/stak.go
+++ b/lib/kion/stak.go
@@ -40,7 +40,7 @@ func GetSTAK(host string, token string, carName string, accNum string) (STAK, er
 		AccountNumber: accNum,
 		CARName:       carName,
 	}
-	resp, err := runQuery("POST", url, token, query, data)
+	resp, _, err := runQuery("POST", url, token, query, data)
 	if err != nil {
 		return STAK{}, err
 	}


### PR DESCRIPTION
This checks for a 403 when querying for accounts as part of STAK generation. If a 403 is received it tries to use a private API endpoint that can provide a list of CARs with associated accounts for a given project.

Closes #7 