### PR TITLE
Fix "unexpected EOF" Error in Bash Subshell Command

### DIFF
--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -141,7 +141,7 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 		}
 		cmd = fmt.Sprintf(`ZDOTDIR=%v zsh`, zdotdir)
 	case "bash":
-		cmd = fmt.Sprintf(`bash --rcfile <(echo "source "$HOME/.bashrc; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
+		cmd = fmt.Sprintf(`bash --rcfile <(echo "source \"$HOME/.bashrc\"; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
 	default:
 		cmd = fmt.Sprintf(`bash --rcfile <(echo "source "$HOME/.bashrc; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
 	}

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -143,7 +143,7 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 	case "bash":
 		cmd = fmt.Sprintf(`bash --rcfile <(echo "source \"$HOME/.bashrc\"; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
 	default:
-		cmd = fmt.Sprintf(`bash --rcfile <(echo "source "$HOME/.bashrc; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
+		cmd = fmt.Sprintf(`bash --rcfile <(echo "source \"$HOME/.bashrc\"; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
 	}
 
 	// init shell


### PR DESCRIPTION
**Problem Description:**  
Users experienced an "unexpected EOF while looking for matching `\"` error when initiating a bash subshell. This was due to improperly escaped quotes in the command string for sourcing the user's `.bashrc` file and setting the `PS1` variable.

**Solution:**  
The fix corrects the command string's escape mechanism for quotes around `$HOME/.bashrc`. Proper escaping ensures that the shell interprets the entire command correctly, thereby preventing the EOF error.