### PR TITLE
Add Default Access Type Indicator to Verbose Favorites Output and Add CLI/Readme QOL changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Kion CLI
 ========
 
-Kion CLI is a tool allowing Kion customers to generate short term access keys and federate into the cloud service provide console via the command line.
+Kion CLI is a tool allowing Kion customers to generate short term access keys and federate into the cloud service provider console via the command line.
 
 ![kion-cli usage](doc/kion-cli-usage.gif)
 
@@ -68,15 +68,16 @@ User Manual
 __Description:__
 
 The Kion CLI allows users to perform common Kion workflows via the command
-line. Users can quickly generate short term access keys (stak) via configured
-favorites or by walking through an account and role selection wizard.
+line. Users can quickly generate short term access keys (stak) or federate
+into the cloud service provider web console via configured favorites or by
+walking through an account and role selection wizard.
 
 __Commands:__
 
 ```text
 stak, s            Generate short-term access keys.
 
-favorite, fav, f   Access pre-configured favorites to quickly generate staks.
+favorite, fav, f   Access pre-configured favorites to quickly generate staks or federate into the cloud service provider console depending on the access_type defined in the favorite.
 
 console, con, c    Federate into the cloud service provider console.
 
@@ -176,7 +177,7 @@ but it is not enabled by default.
    to Users -> Identitiy Management Systems -> click on the SAML IDMS you use
    to login to Kion.  Locate the ID in the URL of this page.
 
-   For example: `http://mykion.example/portal/idms/##`
+   For example: `https://mykion.example/portal/idms/##`
 2. Using the Kion API, add the Kion CLI tool as an additional SAML destination
    by adding `http://localhost:8400/callback` as a supported destination URL.
    Use the `POST /v3/idms/{id}/destination-url` API.

--- a/main.go
+++ b/main.go
@@ -396,7 +396,12 @@ func listFavorites(cCtx *cli.Context) error {
 	// print it out
 	if cCtx.Bool("verbose") {
 		for _, f := range fMap {
-			fmt.Printf(" %v:\n   account number: %v\n   cloud access role: %v\n", f.Name, f.Account, f.CAR)
+			// Check if AccessType is defined; if not, set a default value of "web" in the verbose output
+			accessType := f.AccessType
+			if accessType == "" {
+				accessType = "web (Default)"
+			}
+			fmt.Printf(" %v:\n   account number: %v\n   cloud access role: %v\n   access type: %v\n", f.Name, f.Account, f.CAR, accessType)
 		}
 	} else {
 		for _, f := range fNames {
@@ -633,7 +638,7 @@ func main() {
 			{
 				Name:      "favorite",
 				Aliases:   []string{"fav", "f"},
-				Usage:     "Quickly access a favorite",
+				Usage:     "Quickly access a favorite via federating into the web console or from the cli via a stak.",
 				ArgsUsage: "[FAVORITE_NAME]",
 				Action:    favorites,
 				Flags: []cli.Flag{


### PR DESCRIPTION
## Summary

This PR updates the `listFavorites` function to improve its verbose output by including the `access_type` of each favorite. It addresses the case where `access_type` might not be explicitly defined by defaulting to `"web"` and appending `"(Default)"` to make this fallback behavior transparent to users.

## Changes

- I modified the `listFavorites` to check if `AccessType` is defined for each favorite. It defaults to `"web (Default)"` if not.

## Impact

- **User Experience**: Enhances the verbose output by providing complete information about each favorite, including the access type.
- **Default Handling**: Clearly indicates when the system uses a default value for `access_type`, improving predictability for users.

## Testing

- Tested with a set of favorites with and without `access_type` defined to ensure the output is formatted correctly in both scenarios.
- Verified that existing functionality remains unaffected by these changes.