### PR TITLE
Fixes an issue with favorited web CARs

### DIFF
--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -109,7 +109,7 @@ func GetCARSOnAccount(host string, token string, accID uint) ([]CAR, error) {
 }
 
 // GetCARByNameAndAccount returns a car that matches a given name for a given account number
-func GetCARByName(host string, token string, carName string) (CAR, error) {
+func GetCARByName(host string, token string, carName string, accountNumber string) (CAR, error) {
 	allCars, err := GetCARS(host, token)
 	if err != nil {
 		return CAR{}, err
@@ -117,7 +117,7 @@ func GetCARByName(host string, token string, carName string) (CAR, error) {
 
 	// find our match
 	for _, car := range allCars {
-		if car.Name == carName {
+		if car.Name == carName && car.AccountNumber == accountNumber {
 			return car, nil
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -352,7 +352,7 @@ func favorites(cCtx *cli.Context) error {
 			return helper.CreateSubShell(favorite.Account, favorite.Name, favorite.CAR, stak)
 		}
 	} else {
-		car, err := kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
+		car, err := kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
There's a missing piece of information in the current car by name selection, which looks unintentional. This adds in the account number to the function call and uses that for matching as well as the CAR name.