### PR TITLE
Fix CAR Selection Logic for Web Access Type Favorites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Kion CLI
 ========
 
-Kion CLI is a tool allowing Kion customers to generate short term access keys and federate into the cloud service provide console via the command line.
+Kion CLI is a tool allowing Kion customers to generate short term access keys and federate into the cloud service provider console via the command line.
 
 ![kion-cli usage](doc/kion-cli-usage.gif)
 
@@ -68,15 +68,16 @@ User Manual
 __Description:__
 
 The Kion CLI allows users to perform common Kion workflows via the command
-line. Users can quickly generate short term access keys (stak) via configured
-favorites or by walking through an account and role selection wizard.
+line. Users can quickly generate short term access keys (stak) or federate
+into the cloud service provider web console via configured favorites or by
+walking through an account and role selection wizard.
 
 __Commands:__
 
 ```text
 stak, s            Generate short-term access keys.
 
-favorite, fav, f   Access pre-configured favorites to quickly generate staks.
+favorite, fav, f   Access pre-configured favorites to quickly generate staks or federate into the cloud service provider console depending on the access_type defined in the favorite.
 
 console, con, c    Federate into the cloud service provider console.
 
@@ -176,7 +177,7 @@ but it is not enabled by default.
    to Users -> Identitiy Management Systems -> click on the SAML IDMS you use
    to login to Kion.  Locate the ID in the URL of this page.
 
-   For example: `http://mykion.example/portal/idms/##`
+   For example: `https://mykion.example/portal/idms/##`
 2. Using the Kion API, add the Kion CLI tool as an additional SAML destination
    by adding `http://localhost:8400/callback` as a supported destination URL.
    Use the `POST /v3/idms/{id}/destination-url` API.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ __Commands:__
 stak, s            Generate short-term access keys.
 
 favorite, fav, f   Access pre-configured favorites to quickly generate staks or federate
-                          into the cloud service provider console depending on the access_type
-                          defined in the favorite.
+                   into the cloud service provider console depending on the access_type
+                   defined in the favorite.
 
 console, con, c    Federate into the cloud service provider console.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ __Commands:__
 ```text
 stak, s            Generate short-term access keys.
 
-favorite, fav, f   Access pre-configured favorites to quickly generate staks or federate into the cloud service provider console depending on the access_type defined in the favorite.
+favorite, fav, f   Access pre-configured favorites to quickly generate staks or federate
+                          into the cloud service provider console depending on the access_type
+                          defined in the favorite.
 
 console, con, c    Federate into the cloud service provider console.
 

--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -124,3 +124,20 @@ func GetCARByName(host string, token string, carName string) (CAR, error) {
 
 	return CAR{}, fmt.Errorf("unable to find car %v", carName)
 }
+
+// GetCARByNameAndAccount returns a CAR that matches a given name and account number
+func GetCARByNameAndAccount(host string, token string, carName string, accountNumber string) (CAR, error) {
+	allCars, err := GetCARS(host, token)
+	if err != nil {
+		return CAR{}, err
+	}
+
+	// Find the CAR that matches both the name and account number
+	for _, car := range allCars {
+		if car.Name == carName && car.AccountNumber == accountNumber {
+			return car, nil
+		}
+	}
+
+	return CAR{}, fmt.Errorf("unable to find car %v for account %v", carName, accountNumber)
+}

--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -108,19 +108,19 @@ func GetCARSOnAccount(host string, token string, accID uint) ([]CAR, error) {
 	return cars, nil
 }
 
-// GetCARByNameAndAccount returns a CAR that matches a given name and account number
-func GetCARByNameAndAccount(host string, token string, carName string, accountNumber string) (CAR, error) {
+// GetCARByNameAndAccount returns a car that matches a given name for a given account number
+func GetCARByName(host string, token string, carName string) (CAR, error) {
 	allCars, err := GetCARS(host, token)
 	if err != nil {
 		return CAR{}, err
 	}
 
-	// Find the CAR that matches both the name and account number
+	// find our match
 	for _, car := range allCars {
-		if car.Name == carName && car.AccountNumber == accountNumber {
+		if car.Name == carName {
 			return car, nil
 		}
 	}
 
-	return CAR{}, fmt.Errorf("unable to find car %v for account %v", carName, accountNumber)
+	return CAR{}, fmt.Errorf("unable to find car %v", carName)
 }

--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -108,23 +108,6 @@ func GetCARSOnAccount(host string, token string, accID uint) ([]CAR, error) {
 	return cars, nil
 }
 
-// GetCARByNameAndAccount returns a car that matches a given name for a given account number
-func GetCARByName(host string, token string, carName string) (CAR, error) {
-	allCars, err := GetCARS(host, token)
-	if err != nil {
-		return CAR{}, err
-	}
-
-	// find our match
-	for _, car := range allCars {
-		if car.Name == carName {
-			return car, nil
-		}
-	}
-
-	return CAR{}, fmt.Errorf("unable to find car %v", carName)
-}
-
 // GetCARByNameAndAccount returns a CAR that matches a given name and account number
 func GetCARByNameAndAccount(host string, token string, carName string, accountNumber string) (CAR, error) {
 	allCars, err := GetCARS(host, token)

--- a/main.go
+++ b/main.go
@@ -338,30 +338,30 @@ func favorites(cCtx *cli.Context) error {
 	favorite := fMap[fav]
 
 	// determine favorite action, default to cli unless explicitly set to web
-	if favorite.AccessType != "web" {
+	if favorite.AccessType == "web" {
+		// If access type is specifically set to web
+		car, err := kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
+		if err != nil {
+			return err
+		}
+		car.AccountNumber = favorite.Account
+		url, err := kion.GetFederationURL(cCtx.String("endpoint"), cCtx.String("token"), car)
+		if err != nil {
+			return err
+		}
+		return helper.OpenBrowser(url)
+	} else {
 		// generate stak
 		stak, err := kion.GetSTAK(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
 			return err
 		}
-
 		// print or create subshell
 		if cCtx.Bool("print") {
 			return helper.PrintSTAK(os.Stdout, stak)
 		} else {
 			return helper.CreateSubShell(favorite.Account, favorite.Name, favorite.CAR, stak)
 		}
-	} else {
-		// If access type is specifically set to web
-		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
-		if err != nil {
-			return err
-		}
-		url, err := kion.GetFederationURL(cCtx.String("endpoint"), cCtx.String("token"), car)
-		if err != nil {
-			return err
-		}
-		return helper.OpenBrowser(url)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -352,7 +352,8 @@ func favorites(cCtx *cli.Context) error {
 			return helper.CreateSubShell(favorite.Account, favorite.Name, favorite.CAR, stak)
 		}
 	} else {
-		car, err := kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
+		// Use the new function to get the CAR by both name and account number
+		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
 			return err
 		}
@@ -362,6 +363,7 @@ func favorites(cCtx *cli.Context) error {
 		}
 		return helper.OpenBrowser(url)
 	}
+
 }
 
 // fedConsole opens the csp console for the selected account and cloud access

--- a/main.go
+++ b/main.go
@@ -352,7 +352,6 @@ func favorites(cCtx *cli.Context) error {
 			return helper.CreateSubShell(favorite.Account, favorite.Name, favorite.CAR, stak)
 		}
 	} else {
-		// Use the new function to get the CAR by both name and account number
 		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -638,7 +638,7 @@ func main() {
 			{
 				Name:      "favorite",
 				Aliases:   []string{"fav", "f"},
-				Usage:     "Quickly access a favorite via federating into the web console or from the cli via a stak.",
+				Usage:     "Access favorites via web console or a stak for CLI usage",
 				ArgsUsage: "[FAVORITE_NAME]",
 				Action:    favorites,
 				Flags: []cli.Flag{

--- a/main.go
+++ b/main.go
@@ -396,7 +396,12 @@ func listFavorites(cCtx *cli.Context) error {
 	// print it out
 	if cCtx.Bool("verbose") {
 		for _, f := range fMap {
-			fmt.Printf(" %v:\n   account number: %v\n   cloud access role: %v\n", f.Name, f.Account, f.CAR)
+			// Check if AccessType is defined; if not, set a default value of "web" in the verbose output
+			accessType := f.AccessType
+			if accessType == "" {
+				accessType = "web (Default)"
+			}
+			fmt.Printf(" %v:\n   account number: %v\n   cloud access role: %v\n   access type: %v\n", f.Name, f.Account, f.CAR, accessType)
 		}
 	} else {
 		for _, f := range fNames {
@@ -633,7 +638,7 @@ func main() {
 			{
 				Name:      "favorite",
 				Aliases:   []string{"fav", "f"},
-				Usage:     "Quickly access a favorite",
+				Usage:     "Quickly access a favorite via federating into the web console or from the cli via a stak.",
 				ArgsUsage: "[FAVORITE_NAME]",
 				Action:    favorites,
 				Flags: []cli.Flag{

--- a/main.go
+++ b/main.go
@@ -337,8 +337,8 @@ func favorites(cCtx *cli.Context) error {
 	// grab the favorite object
 	favorite := fMap[fav]
 
-	// determine favorite action, cli or web
-	if favorite.AccessType == "cli" {
+	// determine favorite action, default to cli unless explicitly set to web
+	if favorite.AccessType != "web" {
 		// generate stak
 		stak, err := kion.GetSTAK(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
@@ -352,6 +352,7 @@ func favorites(cCtx *cli.Context) error {
 			return helper.CreateSubShell(favorite.Account, favorite.Name, favorite.CAR, stak)
 		}
 	} else {
+		// If access type is specifically set to web
 		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
 			return err
@@ -362,7 +363,6 @@ func favorites(cCtx *cli.Context) error {
 		}
 		return helper.OpenBrowser(url)
 	}
-
 }
 
 // fedConsole opens the csp console for the selected account and cloud access
@@ -397,10 +397,9 @@ func listFavorites(cCtx *cli.Context) error {
 	// print it out
 	if cCtx.Bool("verbose") {
 		for _, f := range fMap {
-			// Check if AccessType is defined; if not, set a default value of "web" in the verbose output
 			accessType := f.AccessType
 			if accessType == "" {
-				accessType = "web (Default)"
+				accessType = "cli (Default)"
 			}
 			fmt.Printf(" %v:\n   account number: %v\n   cloud access role: %v\n   access type: %v\n", f.Name, f.Account, f.CAR, accessType)
 		}


### PR DESCRIPTION
## Summary

This PR addresses an issue where the application defaulted to opening a browser URL associated with the first cloud access role (CAR) in the list, ignoring the user's favorite account selection for web access type favorites. The core of the problem was the `GetCARByName` function, which did not consider the account number when fetching a CAR, leading to incorrect CAR selection.

## Changes

- I introduced a new function, `GetCARByNameAndAccount,` that accurately filters CARs by both their name and the account number, ensuring the correct CAR is selected based on the user's favorite account.
- Modified the `favorites` function to use this new function when handling web access type favorites, thereby fetching the correct CAR and generating the appropriate federation URL.

## Testing

- Manual testing was conducted with multiple favorites configured, including both CLI and web access types. The correct federation URL was opened for different selected favorites, confirming the issue is resolved.