### PR TITLE
Feature: Enhance User Feedback for Web Access Type Favorites

### DIFF
--- a/main.go
+++ b/main.go
@@ -349,6 +349,7 @@ func favorites(cCtx *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		fmt.Printf("Federating into %s (%s) via %s\n", favorite.Name, favorite.Account, car.AwsIamRoleName)
 		return helper.OpenBrowser(url)
 	} else {
 		// generate stak


### PR DESCRIPTION
## Overview
This PR introduces a user-friendly message that enhances the feedback provided when selecting a favorite with `access_type` set to `web`. This message informs the user about the account name, account number, and the AWS IAM role name being accessed, providing a clearer understanding of the federating process.

## Changes
- Added a `fmt.Printf` statement to display the federating account's name, account number, and AWS IAM role name before opening the browser for web access type favorites.

## Testing
- Manual tests were conducted to ensure the message correctly displays the intended information.
- Verified that the browser opens as expected and the federating process proceeds without any issues.
