### PR TITLE
Update logic on car lookup for web federation

### DIFF
--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -108,7 +108,7 @@ func GetCARSOnAccount(host string, token string, accID uint) ([]CAR, error) {
 	return cars, nil
 }
 
-// GetCARByNameAndAccount returns a car that matches a given name for a given account number
+// GetCARByName returns a car that matches a given name
 func GetCARByName(host string, token string, carName string) (CAR, error) {
 	allCars, err := GetCARS(host, token)
 	if err != nil {
@@ -118,6 +118,23 @@ func GetCARByName(host string, token string, carName string) (CAR, error) {
 	// find our match
 	for _, car := range allCars {
 		if car.Name == carName {
+			return car, nil
+		}
+	}
+
+	return CAR{}, fmt.Errorf("unable to find car %v", carName)
+}
+
+// GetCARByNameAndAccount returns a car that matches by name and account number
+func GetCARByNameAndAccount(host string, token string, carName string, accountNumber string) (CAR, error) {
+	allCars, err := GetCARS(host, token)
+	if err != nil {
+		return CAR{}, err
+	}
+
+	// find our match
+	for _, car := range allCars {
+		if car.Name == carName && car.AccountNumber == accountNumber {
 			return car, nil
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -339,10 +339,11 @@ func favorites(cCtx *cli.Context) error {
 
 	// determine favorite action, default to cli unless explicitly set to web
 	if favorite.AccessType == "web" {
+		var car kion.CAR
 		// attempt to find exact match then fallback to first match
-		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
+		car, err = kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
-			car, err := kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
+			car, err = kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -339,12 +339,15 @@ func favorites(cCtx *cli.Context) error {
 
 	// determine favorite action, default to cli unless explicitly set to web
 	if favorite.AccessType == "web" {
-		// If access type is specifically set to web
-		car, err := kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
+		// attempt to find exact match then fallback to first match
+		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
-			return err
+			car, err := kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
+			if err != nil {
+				return err
+			}
+			car.AccountNumber = favorite.Account
 		}
-		car.AccountNumber = favorite.Account
 		url, err := kion.GetFederationURL(cCtx.String("endpoint"), cCtx.String("token"), car)
 		if err != nil {
 			return err


### PR DESCRIPTION
Attempt to find an exact matching CAR first, if none found fall back to the first match by name only. This workaround is in place due to limitations of the Kion api in returning a full list of CARs for users with minimal project permissions.