### PR TITLE
Add subcommand flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+Change Log
+==========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/). This project adheres to [Semantic Versioning](http://semver.org/) with the exception of version 0 as we find our footing. Only changes to the application should be logged here. Repository maintenance, tests, and other non application changes should be excluded.
+
+[Unreleased] - yyyy-mm-dd
+-------------------------
+
+Notes for upgrading...
+
+### Added
+- Print metadata to stdout when federating into web consoles [https://github.com/kionsoftware/kion-cli/pull/20]
+- Add flags to support headless runs on all commands [https://github.com/kionsoftware/kion-cli/pull/22]
+
+### Changed
+
+- Renamed `access_type` values for clarity [https://github.com/kionsoftware/kion-cli/pull/11]
+- Improve logic around web federation [https://github.com/kionsoftware/kion-cli/pull/21]
+- Dynamically output account name info if available [https://github.com/kionsoftware/kion-cli/pull/22]
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Fix unexpected EOF when creating Bash subshells [https://github.com/kionsoftware/kion-cli/pull/14]
+- Improve CAR selection logic and usage wording [https://github.com/kionsoftware/kion-cli/pull/19]
+- Fix SAML auth around private network access checks [https://github.com/kionsoftware/kion-cli/pull/23]
+
+[0.0.2] - 2024-02-23
+--------------------
+
+### Added
+
+- Web console access! [https://github.com/kionsoftware/kion-cli/pull/10]
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Add workaround for users with `Browse Project - Minimal` permissions [https://github.com/kionsoftware/kion-cli/pull/8]
+- Ensure STAK output can be eval'd [https://github.com/kionsoftware/kion-cli/pull/1]
+
+[0.0.1] - 2024-02-02
+--------------------
+
+Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Notes for upgrading...
 
 ### Added
 - Print metadata to stdout when federating into web consoles [https://github.com/kionsoftware/kion-cli/pull/20]
-- Add flags to support headless runs on all commands [https://github.com/kionsoftware/kion-cli/pull/22]
+- Add flags to support headless runs [https://github.com/kionsoftware/kion-cli/pull/22]
+- Fallback logic for users with restricted perms when using the `run` cmd [https://github.com/kionsoftware/kion-cli/pull/22]
 
 ### Changed
 
@@ -51,4 +52,4 @@ Notes for upgrading...
 [0.0.1] - 2024-02-02
 --------------------
 
-Initial release
+Initial release.

--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ __STAK Options:__
 ```text
 --print, -p                             Print STAK only. (default: false)
 
---account value, --acc value, -a value  Target account number, used to bypass prompts.
+--account value, --acc value, -a value  Target account number, used to bypass prompts,
+                                        must be passed with --car.
 
---car value, -c value                   Target cloud access role, used to bypass prompts.
+--car value, -c value                   Target cloud access role, used to bypass
+                                        prompts, must be passed with --account.
 
 --help, -h                              Print usage text.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ __Global Options:__
 --version, -v                      Print the Kion CLI version.
 ```
 
+__STAK Options:__
+
+```text
+--print, -p                             Print STAK only. (default: false)
+
+--account value, --acc value, -a value  Target account number, used to bypass prompts.
+
+--car value, -c value                   Target cloud access role, used to bypass prompts.
+
+--help, -h                              Print usage text.
+
+```
+
 __Environment:__
 
 Environment variables can be set to enable other modalities of Kion CLI usage.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kionsoftware/kion-cli
 
-go 1.22
-
-toolchain go1.22.0
+go 1.21
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -352,43 +352,43 @@ func PromptPassword(message string) (string, error) {
 ////////////////////////////////////////////////////////////////////////////////
 
 // CARSelector is a wizard that walks a user through the selection of a
-// Project, then associated Accounts, then available Cloud Access Roles,
-// returning the user selected Cloud Access Role. Optional account number and
-// or car name can be passed via an existing car struct, the flow will
-// dynamically ask what is needed to be able to find the full car.
-func CARSelector(cCtx *cli.Context, car kion.CAR) (kion.CAR, error) {
+// Project, then associated Accounts, then available Cloud Access Roles, to set
+// the user selected Cloud Access Role. Optional account number and or car name
+// can be passed via an existing car struct, the flow will dynamically ask what
+// is needed to be able to find the full car.
+func CARSelector(cCtx *cli.Context, car *kion.CAR) error {
 	// if we have what we need go look stuff up without prompts do it
 	if car.AccountNumber != "" && car.Name != "" {
-		carObj, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), car.Name, car.AccountNumber)
+		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), car.Name, car.AccountNumber)
 		if err != nil {
-			return kion.CAR{}, err
+			return err
 		}
 		acc, statusCode, err := kion.GetAccount(cCtx.String("endpoint"), cCtx.String("token"), car.AccountNumber)
 		if err != nil {
 			if statusCode == 403 {
-				return carObj, nil
+				return nil
 			}
-			return kion.CAR{}, err
+			return err
 		}
-		carObj.AccountName = acc.Name
-		carObj.AccountTypeID = acc.TypeID
-		return carObj, nil
+		car.AccountName = acc.Name
+		car.AccountTypeID = acc.TypeID
+		return nil
 	}
 
 	// get list of projects, then build list of names and lookup map
 	projects, err := kion.GetProjects(cCtx.String("endpoint"), cCtx.String("token"))
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 	pNames, pMap := MapProjects(projects)
 	if len(pNames) == 0 {
-		return kion.CAR{}, fmt.Errorf("no projects found")
+		return fmt.Errorf("no projects found")
 	}
 
 	// prompt user to select a project
 	project, err := PromptSelect("Choose a project:", pNames)
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 
 	// get list of accounts on project, then build a list of names and lookup map
@@ -396,55 +396,56 @@ func CARSelector(cCtx *cli.Context, car kion.CAR) (kion.CAR, error) {
 	if err != nil {
 		if statusCode == 403 {
 			// if we're getting a 403 work around permissions bug by temp using private api
-			return carSelectorPrivateAPI(cCtx, pMap, project)
+			return carSelectorPrivateAPI(cCtx, pMap, project, car)
 		} else {
-			return kion.CAR{}, err
+			return err
 		}
 	}
 	aNames, aMap := MapAccounts(accounts)
 	if len(aNames) == 0 {
-		return kion.CAR{}, fmt.Errorf("no accounts found")
+		return fmt.Errorf("no accounts found")
 	}
 
 	// prompt user to select an account
 	account, err := PromptSelect("Choose an Account:", aNames)
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 
 	// get a list of cloud access roles, then build a list of names and lookup map
 	cars, err := kion.GetCARSOnProject(cCtx.String("endpoint"), cCtx.String("token"), pMap[project].ID, aMap[account].ID)
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 	cNames, cMap := MapCAR(cars)
 	if len(cNames) == 0 {
-		return kion.CAR{}, fmt.Errorf("no cloud access roles found")
+		return fmt.Errorf("no cloud access roles found")
 	}
 
 	// prompt user to select a car
 	carname, err := PromptSelect("Choose a Cloud Access Role:", cNames)
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 
 	// inject the account name into the car struct (not returned via api)
-	carObj := cMap[carname]
-	carObj.AccountName = account
-	carObj.AccountTypeID = aMap[account].TypeID
+	selectedCar := cMap[carname]
+	car = &selectedCar
+	car.AccountName = account
+	car.AccountTypeID = aMap[account].TypeID
 
-	// return the selected car
-	return carObj, nil
+	// return nil
+	return nil
 }
 
 // carSelectorPrivateAPI is a temp shim workaround to address a public api
 // permissions issue. CARSelector should be called directly which will the
 // forward to this function if needed.
-func carSelectorPrivateAPI(cCtx *cli.Context, pMap map[string]kion.Project, project string) (kion.CAR, error) {
+func carSelectorPrivateAPI(cCtx *cli.Context, pMap map[string]kion.Project, project string, car *kion.CAR) error {
 	// hit private api endpoint to gather all users cars and their associated accounts
 	caCARs, err := kion.GetConsoleAccessCARS(cCtx.String("endpoint"), cCtx.String("token"), pMap[project].ID)
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 
 	// build a consolidated list of accounts from all available CARS and slice of cars per account
@@ -470,30 +471,30 @@ func carSelectorPrivateAPI(cCtx *cli.Context, pMap map[string]kion.Project, proj
 	// build a list of names and lookup map
 	aNames, aMap := MapAccounts(accounts)
 	if len(aNames) == 0 {
-		return kion.CAR{}, fmt.Errorf("no accounts found")
+		return fmt.Errorf("no accounts found")
 	}
 
 	// prompt user to select an account
 	account, err := PromptSelect("Choose an Account:", aNames)
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 
 	// prompt user to select car
-	car, err := PromptSelect("Choose a Cloud Access Role:", aToCMap[account])
+	carname, err := PromptSelect("Choose a Cloud Access Role:", aToCMap[account])
 	if err != nil {
-		return kion.CAR{}, err
+		return err
 	}
 
 	// build enough of a car and return it
-	return kion.CAR{
-		Name:                car,
-		AccountName:         account,
-		AccountNumber:       aMap[account].Number,
-		AccountID:           aMap[account].ID,
-		AwsIamRoleName:      cMap[car].AwsIamRoleName,
-		AccountTypeID:       aMap[account].TypeID,
-		ID:                  cMap[car].CARID,
-		CloudAccessRoleType: cMap[car].CARRoleType,
-	}, nil
+	car.Name = carname
+	car.AccountName = account
+	car.AccountNumber = aMap[account].Number
+	car.AccountID = aMap[account].ID
+	car.AwsIamRoleName = cMap[carname].AwsIamRoleName
+	car.AccountTypeID = aMap[account].TypeID
+	car.ID = cMap[carname].CARID
+	car.CloudAccessRoleType = cMap[carname].CARRoleType
+
+	return nil
 }

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -366,22 +366,25 @@ func PromptPassword(message string) (string, error) {
 // CARSelector is a wizard that walks a user through the selection of a
 // Project, then associated Accounts, then available Cloud Access Roles,
 // returning the user selected Cloud Access Role. Optional account number and
-// or car name can be passed via an existing car, the flow will dynamically ask
-// what is needed to find the missing information.
+// or car name can be passed via an existing car struct, the flow will
+// dynamically ask what is needed to be able to find the full car.
 func CARSelector(cCtx *cli.Context, car kion.CAR) (kion.CAR, error) {
+	// if we have what we need go look stuff up without prompts do it
 	if car.AccountNumber != "" && car.Name != "" {
-		// we have what we need go look stuff up
-		newcar, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), car.Name, car.AccountNumber)
+		carObj, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), car.Name, car.AccountNumber)
 		if err != nil {
 			return kion.CAR{}, err
 		}
-		acc, err := kion.GetAccount(cCtx.String("endpoint"), cCtx.String("token"), car.AccountNumber)
+		acc, statusCode, err := kion.GetAccount(cCtx.String("endpoint"), cCtx.String("token"), car.AccountNumber)
 		if err != nil {
+			if statusCode == 403 {
+				return carObj, nil
+			}
 			return kion.CAR{}, err
 		}
-		newcar.AccountName = acc.Name
-		newcar.AccountTypeID = acc.TypeID
-		return newcar, nil
+		carObj.AccountName = acc.Name
+		carObj.AccountTypeID = acc.TypeID
+		return carObj, nil
 	}
 
 	// get list of projects, then build list of names and lookup map
@@ -394,56 +397,35 @@ func CARSelector(cCtx *cli.Context, car kion.CAR) (kion.CAR, error) {
 		return kion.CAR{}, fmt.Errorf("no projects found")
 	}
 
-	var acc kion.Account
-	var proj kion.Project
+	// prompt user to select a project
+	project, err := PromptSelect("Choose a project:", pNames)
+	if err != nil {
+		return kion.CAR{}, err
+	}
 
-	if car.AccountNumber != "" {
-		// we have an account number, find available cars and prompt
-		newacc, err := kion.GetAccount(cCtx.String("endpoint"), cCtx.String("token"), car.AccountNumber)
-		if err != nil {
+	// get list of accounts on project, then build a list of names and lookup map
+	accounts, statusCode, err := kion.GetAccountsOnProject(cCtx.String("endpoint"), cCtx.String("token"), pMap[project].ID)
+	if err != nil {
+		if statusCode == 403 {
+			// if we're getting a 403 work around permissions bug by temp using private api
+			return carSelectorPrivateAPI(cCtx, pMap, project)
+		} else {
 			return kion.CAR{}, err
 		}
-		acc = *newacc
-		car.AccountName = acc.Name
-		car.AccountTypeID = acc.TypeID
-		// TODO: figure out how to get the project
-		proj.ID = acc.ProjectID
-	} else {
+	}
+	aNames, aMap := MapAccounts(accounts)
+	if len(aNames) == 0 {
+		return kion.CAR{}, fmt.Errorf("no accounts found")
+	}
 
-		// prompt user to select a project
-		project, err := PromptSelect("Choose a project:", pNames)
-		if err != nil {
-			return kion.CAR{}, err
-		}
-
-		// get list of accounts on project, then build a list of names and lookup map
-		accounts, statusCode, err := kion.GetAccountsOnProject(cCtx.String("endpoint"), cCtx.String("token"), pMap[project].ID)
-		if err != nil {
-			if statusCode == 403 {
-				// if we're getting a 403 work around permissions bug by temp using private api
-				return carSelectorPrivateAPI(cCtx, pMap, project)
-			} else {
-				return kion.CAR{}, err
-			}
-		}
-		aNames, aMap := MapAccounts(accounts)
-		if len(aNames) == 0 {
-			return kion.CAR{}, fmt.Errorf("no accounts found")
-		}
-
-		// prompt user to select an account
-		account, err := PromptSelect("Choose an Account:", aNames)
-		if err != nil {
-			return kion.CAR{}, err
-		}
-		acc = aMap[account]
-		proj = pMap[project]
-		car.AccountName = acc.Name
-		car.AccountTypeID = acc.TypeID
+	// prompt user to select an account
+	account, err := PromptSelect("Choose an Account:", aNames)
+	if err != nil {
+		return kion.CAR{}, err
 	}
 
 	// get a list of cloud access roles, then build a list of names and lookup map
-	cars, err := kion.GetCARSOnProject(cCtx.String("endpoint"), cCtx.String("token"), proj.ID, acc.ID)
+	cars, err := kion.GetCARSOnProject(cCtx.String("endpoint"), cCtx.String("token"), pMap[project].ID, aMap[account].ID)
 	if err != nil {
 		return kion.CAR{}, err
 	}
@@ -453,16 +435,6 @@ func CARSelector(cCtx *cli.Context, car kion.CAR) (kion.CAR, error) {
 		return kion.CAR{}, fmt.Errorf("no cloud access roles found")
 	}
 
-	if car.Name != "" {
-		// we have a car name already
-		newcar, ok := cMap[car.Name]
-		if ok {
-			newcar.AccountName = car.AccountName
-			newcar.AccountTypeID = car.AccountTypeID
-			return newcar, nil
-		}
-	}
-
 	// prompt user to select a car
 	carname, err := PromptSelect("Choose a Cloud Access Role:", cNames)
 	if err != nil {
@@ -470,12 +442,12 @@ func CARSelector(cCtx *cli.Context, car kion.CAR) (kion.CAR, error) {
 	}
 
 	// inject the account name into the car struct (not returned via api)
-	newcar := cMap[carname]
-	newcar.AccountName = car.AccountName
-	newcar.AccountTypeID = car.AccountTypeID
+	carObj := cMap[carname]
+	carObj.AccountName = account
+	carObj.AccountTypeID = aMap[account].TypeID
 
 	// return the selected car
-	return newcar, nil
+	return carObj, nil
 }
 
 // carSelectorPrivateAPI is a temp shim workaround to address a public api

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -431,7 +431,6 @@ func CARSelector(cCtx *cli.Context, car kion.CAR) (kion.CAR, error) {
 	}
 	cNames, cMap := MapCAR(cars)
 	if len(cNames) == 0 {
-		fmt.Println("in here")
 		return kion.CAR{}, fmt.Errorf("no cloud access roles found")
 	}
 

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -359,10 +359,17 @@ func PromptPassword(message string) (string, error) {
 func CARSelector(cCtx *cli.Context, car *kion.CAR) error {
 	// if we have what we need go look stuff up without prompts do it
 	if car.AccountNumber != "" && car.Name != "" {
-		car, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), car.Name, car.AccountNumber)
+		// lookup the car details and populate the passed car
+		foundcar, err := kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), car.Name, car.AccountNumber)
 		if err != nil {
 			return err
 		}
+		car.AccountID = foundcar.AccountID
+		car.AwsIamRoleName = foundcar.AwsIamRoleName
+		car.ID = foundcar.ID
+		car.CloudAccessRoleType = foundcar.CloudAccessRoleType
+
+		// attempt to get account metadata
 		acc, statusCode, err := kion.GetAccount(cCtx.String("endpoint"), cCtx.String("token"), car.AccountNumber)
 		if err != nil {
 			if statusCode == 403 {

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -118,7 +118,6 @@ func OpenBrowser(url string) error {
 // while overriding the prompt to indicate the authed AWS account.
 func CreateSubShell(accountNumber string, accountAlias string, carName string, stak kion.STAK) error {
 	// check if we know the account name
-	nameless := accountAlias == ""
 	var accountMeta string
 	var accountMetaSentence string
 	if accountAlias == "" {

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -428,11 +428,15 @@ func CARSelector(cCtx *cli.Context, car *kion.CAR) error {
 		return err
 	}
 
-	// inject the account name into the car struct (not returned via api)
-	selectedCar := cMap[carname]
-	car = &selectedCar
+	// inject the metaata into the car
+	car.Name = carname
 	car.AccountName = account
+	car.AccountNumber = aMap[account].Number
 	car.AccountTypeID = aMap[account].TypeID
+	car.AccountID = aMap[account].ID
+	car.AwsIamRoleName = cMap[carname].AwsIamRoleName
+	car.ID = cMap[carname].ID
+	car.CloudAccessRoleType = cMap[carname].CloudAccessRoleType
 
 	// return nil
 	return nil

--- a/lib/kion/account.go
+++ b/lib/kion/account.go
@@ -61,22 +61,22 @@ func GetAccountsOnProject(host string, token string, id uint) ([]Account, int, e
 }
 
 // GetAccount returns an account by the given account number
-func GetAccount(host string, token string, accountNum string) (*Account, error) {
+func GetAccount(host string, token string, accountNum string) (*Account, int, error) {
 	// build our query and get response
 	url := fmt.Sprintf("%v/api/v3/account/by-account-number/%v", host, accountNum)
 	query := map[string]string{}
 	var data interface{}
-	resp, _, err := runQuery("GET", url, token, query, data)
+	resp, statusCode, err := runQuery("GET", url, token, query, data)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
 	// unmarshal response body
 	accResp := AccountResponse{}
 	jsonErr := json.Unmarshal(resp, &accResp)
 	if jsonErr != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return &accResp.Account, nil
+	return &accResp.Account, accResp.Status, nil
 }

--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -141,3 +141,34 @@ func GetCARByNameAndAccount(host string, token string, carName string, accountNu
 
 	return CAR{}, fmt.Errorf("unable to find car %v", carName)
 }
+
+// GetAllCARsByName returns a slice of cars that matches a given name
+func GetAllCARsByName(host string, token string, carName string) ([]CAR, error) {
+	allCars, err := GetCARS(host, token)
+	if err != nil {
+		return nil, err
+	}
+
+	// find our matches
+	var cars []CAR
+	for _, car := range allCars {
+		if car.Name == carName {
+			account, err := GetAccount(host, token, car.AccountNumber)
+			if err != nil {
+				// TODO: this may not be what we want to do here, kept as info level log
+				fmt.Println("  unable to lookup an associated account:", car.AccountNumber)
+				continue
+			}
+			car.AccountName = account.Name
+			car.AccountTypeID = account.TypeID
+			cars = append(cars, car)
+		}
+	}
+
+	// return our slice of cars
+	if len(cars) > 0 {
+		return cars, nil
+	}
+
+	return nil, fmt.Errorf("unable to find car %v", carName)
+}

--- a/lib/kion/car.go
+++ b/lib/kion/car.go
@@ -153,10 +153,10 @@ func GetAllCARsByName(host string, token string, carName string) ([]CAR, error) 
 	var cars []CAR
 	for _, car := range allCars {
 		if car.Name == carName {
-			account, err := GetAccount(host, token, car.AccountNumber)
+			account, _, err := GetAccount(host, token, car.AccountNumber)
 			if err != nil {
 				// TODO: this may not be what we want to do here, kept as info level log
-				fmt.Println("  unable to lookup an associated account:", car.AccountNumber)
+				// fmt.Println("  unable to lookup an associated account:", car.AccountNumber)
 				continue
 			}
 			car.AccountName = account.Name

--- a/main.go
+++ b/main.go
@@ -289,12 +289,13 @@ func genStaks(cCtx *cli.Context) error {
 	}
 
 	// init a car object and populate it with any passed arguments
-	var car kion.CAR
-	car.AccountNumber = cCtx.String("account")
-	car.Name = cCtx.String("car")
+	car := &kion.CAR{
+		AccountNumber: cCtx.String("account"),
+		Name:          cCtx.String("car"),
+	}
 
 	// run through the car selector to fill any gaps
-	err = helper.CARSelector(cCtx, &car)
+	err = helper.CARSelector(cCtx, car)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -294,7 +294,7 @@ func genStaks(cCtx *cli.Context) error {
 	car.Name = cCtx.String("car")
 
 	// run through the car selector to fill any gaps
-	car, err = helper.CARSelector(cCtx, car)
+	err = helper.CARSelector(cCtx, &car)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,8 @@ func fedConsole(cCtx *cli.Context) error {
 	}
 
 	// walk user through the prompt workflow to select a car
-	car, err := helper.CARSelector(cCtx, kion.CAR{})
+	var car kion.CAR
+	err = helper.CARSelector(cCtx, &car)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -390,7 +390,7 @@ func fedConsole(cCtx *cli.Context) error {
 		return err
 	}
 
-	// TODO: handle arg if passed else run prompts
+	// grab the csp federation url
 	url, err := kion.GetFederationURL(cCtx.String("endpoint"), cCtx.String("token"), car)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -658,12 +658,12 @@ func main() {
 					&cli.StringFlag{
 						Name:    "account",
 						Aliases: []string{"acc", "a"},
-						Usage:   "target account number",
+						Usage:   "target account number, must be passed with car",
 					},
 					&cli.StringFlag{
 						Name:    "car",
 						Aliases: []string{"c"},
-						Usage:   "target cloud access role",
+						Usage:   "target cloud access role, must be passed with account",
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -288,8 +288,13 @@ func genStaks(cCtx *cli.Context) error {
 		return err
 	}
 
-	// walk user through the propt workflow to select a car
-	car, err := helper.CARSelector(cCtx)
+	// init a car object and populate it with any passed arguments
+	var car kion.CAR
+	car.AccountNumber = cCtx.String("account")
+	car.Name = cCtx.String("car")
+
+	// run through the car selector to fill any gaps
+	car, err = helper.CARSelector(cCtx, car)
 	if err != nil {
 		return err
 	}
@@ -380,7 +385,7 @@ func fedConsole(cCtx *cli.Context) error {
 	}
 
 	// walk user through the prompt workflow to select a car
-	car, err := helper.CARSelector(cCtx)
+	car, err := helper.CARSelector(cCtx, kion.CAR{})
 	if err != nil {
 		return err
 	}
@@ -631,6 +636,16 @@ func main() {
 						Name:    "print",
 						Aliases: []string{"p"},
 						Usage:   "print stak only",
+					},
+					&cli.StringFlag{
+						Name:    "account",
+						Aliases: []string{"acc", "a"},
+						Usage:   "target account number",
+					},
+					&cli.StringFlag{
+						Name:    "car",
+						Aliases: []string{"c"},
+						Usage:   "target cloud access role",
 					},
 				},
 			},


### PR DESCRIPTION
Allows users to pass `--account [number]` and ~~or~~ `--car [name]` to bypass prompts when generating short term access keys / starting sessions. Helpful to allow fully headless operation without having to setup favorites.