### PR TITLE
Fix SAML auth to work with private network access checks

### DIFF
--- a/lib/kion/saml.go
+++ b/lib/kion/saml.go
@@ -97,6 +97,12 @@ func AuthenticateSAML(appUrl string, metadata *samlTypes.EntityDescriptor, servi
 	tokenChan := make(chan SamlCallbackResult, 1)
 	http.HandleFunc("/", func(rw http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.URL.String(), "/favicon.ico") {
+			http.NotFound(rw, req)
+			return
+		}
+
+		// Ensure we work with private network access check preflight requests
+		if req.Method == "OPTIONS" {
 			return
 		}
 


### PR DESCRIPTION
Chrome 123 added [private network access checks](https://developer.chrome.com/blog/chrome-123-beta#private_network_access_checks_for_navigation_requests_warning-only_mode) via a pre-flight OPTIONS request.  

This PR updates the callback server to respond 200, but otherwise ignore OPTIONS checks.