### PR TITLE
Add initial region support for run & stak commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Notes for upgrading...
 - Fallback logic for users with restricted perms when using the `run` cmd [https://github.com/kionsoftware/kion-cli/pull/22]
 - Logic to accommodate users with cloud access only permissions [https://github.com/kionsoftware/kion-cli/pull/24]
 - STAK selection wizard now includes project and car IDs and account numbers [https://github.com/kionsoftware/kion-cli/pull/24]
+- Support defining region on favorites or via flag [https://github.com/kionsoftware/kion-cli/pull/26]
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Setup
       - name: sandbox
         account: "111122223333"
         cloud_access_role: Admin
-        access_type: web
+        access_type: web               # optional (defaults to cli)
+        region: us-gov-west-1          # optional
       - name: prod
         account: "111122224444"
         cloud_access_role: ReadOnly
-        access_type: cli
     ```
 
 User Manual
@@ -130,19 +130,59 @@ __Global Options:__
 --version, -v                      Print the Kion CLI version.
 ```
 
-__STAK Options:__
+__STAK Command:__
 
 ```text
---print, -p                             Print STAK only. (default: false)
+OPTIONS
 
---account value, --acc value, -a value  Target account number, used to bypass prompts,
-                                        must be passed with --car.
+  --print, -p                          Print STAK only. (default: false)
 
---car value, -c value                   Target cloud access role, used to bypass
-                                        prompts, must be passed with --account.
+  --account val, -acc val, -a val      Target account number, used to bypass
+                                       prompts, must be passed with --car.
 
---help, -h                              Print usage text.
+  --car val, -c val                    Target cloud access role, used to bypass
+                                       prompts, must be passed with --account.
 
+  --region val, -r val                 Specify which region to target.
+
+  --help, -h                           Print usage text.
+```
+
+__Favorite Command:__
+
+```text
+SUB COMMANDS
+
+  list                                 List all configured favorites. List
+                                       accepts a --verbose / -v option to print
+                                       additional details.
+
+OPTIONS
+
+  --print, -p                          Print STAK only. Has no effect on
+                                       favorites with an "access_type" of
+                                       "web". (default: false)
+
+
+  --help, -h                           Print usage text.
+```
+
+__Run Command:__
+
+```text
+OPTIONS
+
+  --favorite val,  -fav val, -f val    Specify which favorite to run against.
+
+  --account val, -acc val, -a val      Specify which account to target, must be
+                                       passed with --car.
+
+  --car val, -c val                    Specify which Cloud Access Role to use,
+                                       must be passed with --account.
+
+  --region val, -r val                 Specify which region to target.
+
+  --help, -h                           Print usage text.
 ```
 
 __Environment:__

--- a/README.md
+++ b/README.md
@@ -326,3 +326,4 @@ Contributing
 1. Ensure you have golang installed and configured.
 2. Clone the repository and initialize with `make init`. This will setup the necessary git hooks and other needed tools.
 3. Create and populate your `~/.kion.yml` configuration file. See the example at the top of this document.
+4. When submitting a PR be sure to note your changes in the `CHANGELOG.md`.

--- a/lib/helper/helper_test.go
+++ b/lib/helper/helper_test.go
@@ -122,11 +122,13 @@ func TestPrintSTAK(t *testing.T) {
 	tests := []struct {
 		description string
 		stak        kion.STAK
+		region      string
 		want        string
 	}{
 		{
 			"Empty",
 			kion.STAK{},
+			"",
 			"export AWS_ACCESS_KEY_ID=\nexport AWS_SECRET_ACCESS_KEY=\nexport AWS_SESSION_TOKEN=\n",
 		},
 		// {
@@ -141,6 +143,7 @@ func TestPrintSTAK(t *testing.T) {
 				SecretAccessKey: "aBCDeFg1hijkl2m3NOPqr4StUvWxY56z7abc8DEf",
 				SessionToken:    "",
 			},
+			"",
 			"export AWS_ACCESS_KEY_ID=\nexport AWS_SECRET_ACCESS_KEY=aBCDeFg1hijkl2m3NOPqr4StUvWxY56z7abc8DEf\nexport AWS_SESSION_TOKEN=\n",
 		},
 		{
@@ -150,7 +153,18 @@ func TestPrintSTAK(t *testing.T) {
 				SecretAccessKey: "aBCDeFg1hijkl2m3NOPqr4StUvWxY56z7abc8DEf",
 				SessionToken:    "AbcDEFghIJKlMNoPQrStuVwXYZabcDEfGhI1JklmNoPQRStu2VWXYZaBcd34ef+GH+IJKLmNOPQRSTU5VwxyzABcdeFGHIj6KlMNoPQ7rSTUvW8X9yZAbCD0ef+gHIJkLMnoPqrstUVwxyzAb1CD2e34fgHiJKlMnOPqr56STuvwXyzABcdEfgh7IJK+8LM91No2pqrSTuvWxyz3ABCdEFGH4ijklMNOP5qrs6TUvWxyz789abcDefgH12iJKlM3no4pQRs+5t6UVw7/xy+ZaBcdE+FGhIj8kLmnOpqrstuvw9xyzab1cD/ef23GhIjkLMNoPQrstuv=",
 			},
+			"",
 			"export AWS_ACCESS_KEY_ID=ASIAABCDEFGHIJ1K23LM\nexport AWS_SECRET_ACCESS_KEY=aBCDeFg1hijkl2m3NOPqr4StUvWxY56z7abc8DEf\nexport AWS_SESSION_TOKEN=AbcDEFghIJKlMNoPQrStuVwXYZabcDEfGhI1JklmNoPQRStu2VWXYZaBcd34ef+GH+IJKLmNOPQRSTU5VwxyzABcdeFGHIj6KlMNoPQ7rSTUvW8X9yZAbCD0ef+gHIJkLMnoPqrstUVwxyzAb1CD2e34fgHiJKlMnOPqr56STuvwXyzABcdEfgh7IJK+8LM91No2pqrSTuvWxyz3ABCdEFGH4ijklMNOP5qrs6TUvWxyz789abcDefgH12iJKlM3no4pQRs+5t6UVw7/xy+ZaBcdE+FGhIj8kLmnOpqrstuvw9xyzab1cD/ef23GhIjkLMNoPQrstuv=\n",
+		},
+		{
+			"With Region",
+			kion.STAK{
+				AccessKey:       "ASIAABCDEFGHIJ1K23LM",
+				SecretAccessKey: "aBCDeFg1hijkl2m3NOPqr4StUvWxY56z7abc8DEf",
+				SessionToken:    "AbcDEFghIJKlMNoPQrStuVwXYZabcDEfGhI1JklmNoPQRStu2VWXYZaBcd34ef+GH+IJKLmNOPQRSTU5VwxyzABcdeFGHIj6KlMNoPQ7rSTUvW8X9yZAbCD0ef+gHIJkLMnoPqrstUVwxyzAb1CD2e34fgHiJKlMnOPqr56STuvwXyzABcdEfgh7IJK+8LM91No2pqrSTuvWxyz3ABCdEFGH4ijklMNOP5qrs6TUvWxyz789abcDefgH12iJKlM3no4pQRs+5t6UVw7/xy+ZaBcdE+FGhIj8kLmnOpqrstuvw9xyzab1cD/ef23GhIjkLMNoPQrstuv=",
+			},
+			"us-gov-west-1",
+			"export AWS_REGION=us-gov-west-1\nexport AWS_ACCESS_KEY_ID=ASIAABCDEFGHIJ1K23LM\nexport AWS_SECRET_ACCESS_KEY=aBCDeFg1hijkl2m3NOPqr4StUvWxY56z7abc8DEf\nexport AWS_SESSION_TOKEN=AbcDEFghIJKlMNoPQrStuVwXYZabcDEfGhI1JklmNoPQRStu2VWXYZaBcd34ef+GH+IJKLmNOPQRSTU5VwxyzABcdeFGHIj6KlMNoPQ7rSTUvW8X9yZAbCD0ef+gHIJkLMnoPqrstUVwxyzAb1CD2e34fgHiJKlMnOPqr56STuvwXyzABcdEfgh7IJK+8LM91No2pqrSTuvWxyz3ABCdEFGH4ijklMNOP5qrs6TUvWxyz789abcDefgH12iJKlM3no4pQRs+5t6UVw7/xy+ZaBcdE+FGhIj8kLmnOpqrstuvw9xyzab1cD/ef23GhIjkLMNoPQrstuv=\n",
 		},
 	}
 
@@ -166,7 +180,7 @@ func TestPrintSTAK(t *testing.T) {
 			}()
 
 			var output bytes.Buffer
-			err := PrintSTAK(&output, test.stak)
+			err := PrintSTAK(&output, test.stak, test.region)
 			if err != nil {
 				t.Error(err)
 			}

--- a/lib/structs/structs.go
+++ b/lib/structs/structs.go
@@ -35,4 +35,5 @@ type Favorite struct {
 	Account    string `yaml:"account"`
 	CAR        string `yaml:"cloud_access_role"`
 	AccessType string `yaml:"access_type"`
+	Region     string `yaml:"region"`
 }


### PR DESCRIPTION
Users can set a region on their favorites or pass a region via a flag. Will conditionally set AWS_REGION as needed. Also works with stak gen when printing.

Closes: #3 