### PR TITLE
Add compatibility commands for ctkey

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,44 +6,55 @@ output:
   print-issued-lines: true
   print-linter-name: true
 linters-settings:
+  dupl:
+    threshold: 150
   errcheck:
     check-type-assertions: false
     check-blank: false
-  govet:
-    enable:
-      - shadow
-  gofmt:
-    simplify: true
-  goimports:
-    local-prefixes: github.com/org/project
-  gocyclo:
-    min-complexity: 30
-  dupl:
-    threshold: 150
   goconst:
     min-len: 3
     min-occurrences: 3
+  gocyclo:
+    min-complexity: 30
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: github.com/kionsoftware/kion-cli
+  govet:
+    enable:
+      - shadow
+  lll:
+    line-length: 120
+    tab-width: 1
   misspell:
     locale: US
     ignore-words:
       - cancelled
-  lll:
-    line-length: 120
-    tab-width: 1
+  sloglint:
+    attr-only: true
   unparam:
     check-exported: false
 linters:
   disable-all: true
   enable:
-    - govet
+    - asciicheck
+    # - dupl
     - errcheck
-    - ineffassign
-    - unconvert
-    - gofmt
-    - misspell
-    - unparam
-    - gosimple # normally implicit
     - bodyclose
+    - goconst
+    - gocyclo
+    - gofmt
+    # - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    # - lll
+    - misspell
+    - sloglint
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
 issues:
   exclude:
     - "shadow: declaration of .err. shadows declaration"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters-settings:
     check-blank: false
   goconst:
     min-len: 3
-    min-occurrences: 3
+    min-occurrences: 5
   gocyclo:
     min-complexity: 30
   gofmt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Notes for upgrading...
 - STAK selection wizard now includes project and car IDs and account numbers [https://github.com/kionsoftware/kion-cli/pull/24]
 - Automate AWS logout before federating into the AWS console [https://github.com/kionsoftware/kion-cli/pull/25]
 - Support defining region on favorites or via flag [https://github.com/kionsoftware/kion-cli/pull/26]
+- Support for old `ctkey` usage by adding compatibility commands [https://github.com/kionsoftware/kion-cli/pull/28]
+- Ability to save short-term access keys to an AWS credentials profile [https://github.com/kionsoftware/kion-cli/pull/28]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Notes for upgrading...
 - Support defining region on favorites or via flag [https://github.com/kionsoftware/kion-cli/pull/26]
 - Support for old `ctkey` usage by adding compatibility commands [https://github.com/kionsoftware/kion-cli/pull/28]
 - Ability to save short-term access keys to an AWS credentials profile [https://github.com/kionsoftware/kion-cli/pull/28]
+- Add support for windows when printing STAKs for export [https://github.com/kionsoftware/kion-cli/pull/28]
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ run                Run a command with short-term access keys
 
 help, h            Print usage text.
 
-COMPATIBILITY COMMANDS:
+
+The following are maintained for compatibility with older Kion utilities:
 
 view               Generate short-team access keys and print to standard out.
                    This is effectively 'stak --print'.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ help, h            Print usage text.
 COMPATIBILITY COMMANDS:
 
 view               Generate short-team access keys and print to standard out.
+                   This is effectively 'stak --print'.
 
 savecreds          Store short-term access keys to an AWS credentials profile.
+                   This is effectively 'stak --save'.
 ```
 
 __Files:__

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ __Commands:__
 ```text
 stak, s            Generate short-term access keys.
 
+
 favorite, fav, f   Access pre-configured favorites to quickly generate staks or federate
                    into the cloud service provider console depending on the access_type
                    defined in the favorite.
@@ -90,6 +91,12 @@ console, con, c    Federate into the cloud service provider console.
 run                Run a command with short-term access keys
 
 help, h            Print usage text.
+
+COMPATIBILITY COMMANDS:
+
+view               Generate short-team access keys and print to standard out.
+
+savecreds          Store short-term access keys to an AWS credentials profile.
 ```
 
 __Files:__
@@ -102,32 +109,32 @@ __Files:__
 __Global Options:__
 
 ```text
---endpoint URL, -e URL             URL of the Kion instance to interface with.
+--endpoint URL, -e URL, --url URL      URL of the Kion instance to interface with.
 
---user USERNAME, -u USERNAME       Username used for authenticating with Kion.
+--user USER, -u USER, --username USER  Username used for authenticating with Kion.
 
---password PASSWORD, -p PASSWORD   Password used for authenticating with Kion.
+--password PASSWORD, -p PASSWORD       Password used for authenticating with Kion.
 
---idms IDMS_ID, -i IDMS_ID         IDMS ID with which to authenticate if using
-                                   username and password. If only one IDMS is
-                                   configured that uses username and password
-                                   it is not required to specify its ID.
+--idms IDMS_ID, -i IDMS_ID             IDMS ID with which to authenticate if using
+                                       username and password. If only one IDMS is
+                                       configured that uses username and password
+                                       it is not required to specify its ID.
 
---saml_metadata_file FILENAME|URL  FILENAME or URL of the identity provider's
-                                   XML metadata document.  If a URL, this file
-                                   will be downloaded every time the CLI app
-                                   is run.  If a local file, this should be an
-                                   absolute path to a file on your computer.
+--saml_metadata_file FILENAME|URL      FILENAME or URL of the identity provider's
+                                       XML metadata document.  If a URL, this file
+                                       will be downloaded every time the CLI app
+                                       is run.  If a local file, this should be an
+                                       absolute path to a file on your computer.
 
---saml_sp_issuer ISSUER            SAML Service Provider issuer value from Kion
-                                   for example:
-                                   https://mykioninstance.example/api/v1/saml/auth/1
+--saml_sp_issuer ISSUER                SAML Service Provider issuer value from Kion
+                                       for example:
+                                       https://mykioninstance.example/api/v1/saml/auth/1
 
---token TOKEN, -t TOKEN            Token (API or Bearer) used to authenticate.
+--token TOKEN, -t TOKEN                Token (API or Bearer) used to authenticate.
 
---help, -h                         Print usage text.
+--help, -h                             Print usage text.
 
---version, -v                      Print the Kion CLI version.
+--version, -v                          Print the Kion CLI version.
 ```
 
 __STAK Command:__
@@ -137,13 +144,17 @@ OPTIONS
 
   --print, -p                          Print STAK only. (default: false)
 
-  --account val, -acc val, -a val      Target account number, used to bypass
+  --account val, --acc val, -a val     Target account number, used to bypass
                                        prompts, must be passed with --car.
 
-  --car val, -c val                    Target cloud access role, used to bypass
-                                       prompts, must be passed with --account.
+  --car val, --cloud-access-role val,  Target cloud access role, used to bypass
+    -c val                             prompts, must be passed with --account.
 
   --region val, -r val                 Specify which region to target.
+
+  --save, -s                           Save short-term keys to an aws credentials
+                                       profile. The print flag will supercede this
+                                       option.
 
   --help, -h                           Print usage text.
 ```
@@ -172,7 +183,7 @@ __Run Command:__
 ```text
 OPTIONS
 
-  --favorite val,  -fav val, -f val    Specify which favorite to run against.
+  --favorite val, --fav val, -f val    Specify which favorite to run against.
 
   --account val, -acc val, -a val      Specify which account to target, must be
                                        passed with --car.
@@ -193,26 +204,58 @@ Kion CLI follows standard precedence for defining configurations:
   `Flag > Environment Variable > Configuration File > Default Value`
 
 ```text
-KION_URL        URL of the Kion instance to interact with.
+KION_URL                 URL of the Kion instance to interact with.
 
-KION_USERNAME   Username used for authenticating with Kion.
+KION_USERNAME            Username used for authenticating with Kion.
 
-KION_PASSWORD   Passwrod used for authenticating with Kion.
+KION_PASSWORD            Passwrod used for authenticating with Kion.
 
-KION_IDMS_ID    IDMS ID with which to authenticate if using username and
-                password. If only one IDMS is configured that uses username and
-                password it is not required to specify its ID.
+KION_IDMS_ID             IDMS ID with which to authenticate if using username and
+                         password. If only one IDMS is configured that uses username and
+                         password it is not required to specify its ID.
 
-KION_API_KEY    API key used to authenticate. Corresponds to the `--token` flag.
+KION_API_KEY             API key used to authenticate. Corresponds to the `--token` flag.
 
 KION_SAML_METADATA_FILE  FILENAME or URL of the identity provider's XML metadata
                          document.  If a URL, this file will be downloaded
                          every time the CLI app is run.  If a local file, this
                          should be an absolute path to a file on your computer.
 
-KION_SAML_SP_ISSUER     The Kion IDMS issuer value, for example
-                        https://mykioninstance.example/api/v1/saml/auth/1
+KION_SAML_SP_ISSUER      The Kion IDMS issuer value, for example
+                         https://mykioninstance.example/api/v1/saml/auth/1
+
+
+The following are maintained for compatibility with older Kion utilities:
+
+CTKEY_USERNAME           Maps to KION_USERNAME.
+
+CTKEY_PASSWORD           Maps to KION_PASSWORD.
+
+CTKEY_APPAPIKEY          Maps to KION_API_KEY
 ```
+
+### Compatibility
+
+Kion-CLI is setup to be a drop in replacement for the older cloudtamer.io
+utility `ctkey` where possible. The one exception is the `--iam-role` options
+flag is no longer supported and must be replaced with `--cloud-access-role`,
+`--car`, or `-c` flag followed by a valid Cloud Access Role name.
+
+```bash
+# old ctkey usage example
+ctkey view --url=https://YOUR-KION-URL --account=121212121212 --cloud-access-role=admin
+# new Kion-CLI example (drop in replacement)
+kion view --url=https://YOUR-KION-URL --account=121212121212 --cloud-access-role=admin
+# new Kion-CLI example (new usage, assumes use of ~/.kion.yml config)
+kion stak --print --account 121212121212 --car admin
+# new Kion-CLI example (short usage, assumes use of ~/.kion.yml config)
+kion s -p -a 121212121212 -c admin
+```
+
+While you can drop in Kion-CLI directly with old usage it is recommended that
+you familiarize yourself with the new methods of access as it is does not
+require modification of AWS CLI configuration files.
+
 
 ### SAML Setup
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ Setup
         cloud_access_role: ReadOnly
     ```
 
+4. Usage examples:
+
+    ```sh
+    # open the sandbox AWS console favorited in the config above
+    kion fav sandbox
+
+    # generate and print keys for an AWS account
+    kion stak --print --account 121212121212 --car Admin
+
+    # start a sub-shell authenticated into an account
+    kion stak --account 121212121212 --car Admin
+
+    # start a sub-shell using a wizard to select a target account and Cloud Rule
+    kion stak
+
+    # federate into a web console using a wizard to select a target account and Cloud Rule
+    kion console
+    ```
+
 User Manual
 -----------
 
@@ -95,7 +114,7 @@ help, h            Print usage text.
 
 The following are maintained for compatibility with older Kion utilities:
 
-view               Generate short-team access keys and print to standard out.
+setenv             Generate short-team access keys and print to standard out.
                    This is effectively 'stak --print'.
 
 savecreds          Store short-term access keys to an AWS credentials profile.
@@ -245,14 +264,23 @@ flag is no longer supported and must be replaced with `--cloud-access-role`,
 `--car`, or `-c` flag followed by a valid Cloud Access Role name.
 
 ```bash
-# old ctkey usage example
-ctkey view --url=https://YOUR-KION-URL --account=121212121212 --cloud-access-role=admin
+# old ctkey usage to print short-term access keys
+ctkey setenv --url=https://YOUR-KION-URL --account=121212121212 --cloud-access-role=admin
 # new Kion-CLI example (drop in replacement)
-kion view --url=https://YOUR-KION-URL --account=121212121212 --cloud-access-role=admin
+kion setenv --url=https://YOUR-KION-URL --account=121212121212 --cloud-access-role=admin
 # new Kion-CLI example (new usage, assumes use of ~/.kion.yml config)
 kion stak --print --account 121212121212 --car admin
 # new Kion-CLI example (short usage, assumes use of ~/.kion.yml config)
 kion s -p -a 121212121212 -c admin
+
+# old ctkey usage to store short-term access keys in an aws configuration profile
+ctkey savecreds --url=https://YOUR-CLOUDTAMER-URL --account=121212121212 --cloud-access-role=admin
+# new Kion-CLI example (drop in replacement)
+kion savecreds --url=https://YOUR-CLOUDTAMER-URL --account=121212121212 --cloud-access-role=admin
+# new Kion-CLI example (new usage, assumes use of ~/.kion.yml config)
+kion stak --save --account 121212121212 --car admin
+# new Kion-CLI example (short usage, assumes use of ~/.kion.yml config)
+kion s -s -a 121212121212 -c admin
 ```
 
 While you can drop in Kion-CLI directly with old usage it is recommended that

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -1,12 +1,15 @@
 package helper
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -88,6 +91,129 @@ func PrintSTAK(w io.Writer, stak kion.STAK, region string) error {
 		fmt.Fprintf(w, "export AWS_REGION=%v\n", region)
 	}
 	fmt.Fprintf(w, "export AWS_ACCESS_KEY_ID=%v\nexport AWS_SECRET_ACCESS_KEY=%v\nexport AWS_SESSION_TOKEN=%v\n", stak.AccessKey, stak.SecretAccessKey, stak.SessionToken)
+	return nil
+}
+
+// SaveAWSCreds saves the short term access keys for AWS auth to the users AWS
+// configuration file.
+func SaveAWSCreds(stak kion.STAK, car kion.CAR) error {
+	// get the current user home directory.
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	// derive aws creds paths
+	awsCredsDir := filepath.Join(user.HomeDir, ".aws")
+	awsCredsFile := filepath.Join(user.HomeDir, ".aws/credentials")
+
+	// if the folder or file does not exist, create them
+	if _, err := os.Stat(awsCredsDir); os.IsNotExist(err) {
+		// create directory
+		errDir := os.MkdirAll(awsCredsDir, 0755)
+		if errDir != nil {
+			log.Fatal(err)
+		}
+	}
+	if _, err := os.Stat(awsCredsFile); os.IsNotExist(err) {
+		err = os.WriteFile(awsCredsFile, []byte(""), 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	b, err := os.ReadFile(awsCredsFile)
+	if err != nil {
+		return err
+	}
+
+	// determine if the profile already exists
+	profileName := fmt.Sprintf("[%v_%v]", car.AccountNumber, car.AwsIamRoleName)
+	index := strings.Index(string(b), profileName)
+
+	// if the profile does not exist, just append
+	if index == -1 {
+		f, err := os.OpenFile(awsCredsFile, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+
+		linebreak := "\n"
+		if runtime.GOOS == "windows" {
+			linebreak = "\r\n"
+		}
+
+		text := ""
+		text += fmt.Sprintf(linebreak+"[%v_%v]"+linebreak, car.AccountNumber, car.AwsIamRoleName)
+		text += fmt.Sprintf("aws_access_key_id=%v"+linebreak, stak.AccessKey)
+		text += fmt.Sprintf("aws_secret_access_key=%v"+linebreak, stak.SecretAccessKey)
+		text += fmt.Sprintf("aws_session_token=%v"+linebreak, stak.SessionToken)
+
+		_, err = f.WriteString(text)
+		if err != nil {
+			return err
+		}
+
+		err = f.Close()
+		if err != nil {
+			return err
+		}
+	} else {
+		// fmt.Println("updating existing profile")
+		f, err := os.Open(awsCredsFile)
+		if err != nil {
+			return err
+		}
+
+		started := false
+
+		buf := ""
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			t := scanner.Text()
+			if strings.Contains(t, profileName) {
+				started = true
+				buf += fmt.Sprintln(t)
+				continue
+			}
+
+			if started {
+				if !strings.Contains(t, "=") {
+					started = false
+					buf += fmt.Sprintln(t)
+					continue
+				}
+
+				switch true {
+				case strings.Contains(t, "aws_access_key_id"):
+					buf += fmt.Sprintln("aws_access_key_id=" + stak.AccessKey)
+				case strings.Contains(t, "aws_secret_access_key"):
+					buf += fmt.Sprintln("aws_secret_access_key=" + stak.SecretAccessKey)
+				case strings.Contains(t, "aws_session_token"):
+					buf += fmt.Sprintln("aws_session_token=" + stak.SessionToken)
+				default:
+					return errors.New("there is a problem with the aws credentials file")
+				}
+				continue
+			}
+			buf += fmt.Sprintln(t)
+		}
+
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+
+		err = os.WriteFile(awsCredsFile, []byte(buf), 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Credentials updated in the file:", awsCredsFile)
+	fmt.Printf("You can reference this profile using this flag: --profile %v_%v\n", car.AccountNumber, car.AwsIamRoleName)
+	fmt.Printf("Example command: aws s3 ls --profile %v_%v\n", car.AccountNumber, car.AwsIamRoleName)
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -337,11 +337,11 @@ func genStaks(cCtx *cli.Context) error {
 		return err
 	}
 
-	// grab the command usage [stak, s, view, savecreds, etc]
+	// grab the command usage [stak, s, setenv, savecreds, etc]
 	cmdUsed := cCtx.Lineage()[1].Args().Slice()[0]
 
 	// print or create sub-shell
-	if cCtx.Bool("print") || cmdUsed == "view" {
+	if cCtx.Bool("print") || cmdUsed == "setenv" {
 		return helper.PrintSTAK(os.Stdout, stak, cCtx.String("region"))
 	} else if cCtx.Bool("save") || cmdUsed == "savecreds" {
 		return helper.SaveAWSCreds(stak, car)
@@ -697,7 +697,7 @@ func main() {
 		Commands: []*cli.Command{
 			{
 				Name:    "stak",
-				Aliases: []string{"view", "savecreds", "s"},
+				Aliases: []string{"setenv", "savecreds", "s"},
 				Usage:   "Generate short-term access keys",
 				Action:  genStaks,
 				Flags: []cli.Flag{


### PR DESCRIPTION
Adds commands to mirror usage and functionality of the older `ctkey` utility. Allows customers to drop in the new kion-cli with minimal reconfiguration.