### PR TITLE
Workaround Firefox limitations for AWS logouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/). This proj
 Notes for upgrading...
 
 ### Added
+
 - Print metadata to stdout when federating into web consoles [https://github.com/kionsoftware/kion-cli/pull/20]
 - Add flags to support headless runs [https://github.com/kionsoftware/kion-cli/pull/22]
 - Fallback logic for users with restricted perms when using the `run` cmd [https://github.com/kionsoftware/kion-cli/pull/22]
@@ -37,6 +38,7 @@ Notes for upgrading...
 - Fix unexpected EOF when creating Bash subshells [https://github.com/kionsoftware/kion-cli/pull/14]
 - Improve CAR selection logic and usage wording [https://github.com/kionsoftware/kion-cli/pull/19]
 - Fix SAML auth around private network access checks [https://github.com/kionsoftware/kion-cli/pull/23]
+- Fixed automated logouts of AWS console sessions on Firefox [https://github.com/kionsoftware/kion-cli/pull/31]
 
 [0.0.2] - 2024-02-23
 --------------------

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Setup
     kion stak
 
     # federate into a web console using a wizard to select a target account and Cloud Rule
+    # * note that Firefox users will have to approve pop-ups on the first run
     kion console
     ```
 

--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -310,25 +310,37 @@ func redirectServer(url string, typeID uint) {
           window.onload = function() {
             let redirectURL = '%v'
             let accountTypeID = '%v'
-            const logout_iframe = document.createElement('iframe');
-            logout_iframe.height = '0';
-            logout_iframe.width = '0';
+            let agent = navigator.userAgent;
             if (accountTypeID == '1') {
                 // commercial
-                logout_iframe.src = 'https://signin.aws.amazon.com/oauth?Action=logout';
+                logoutURL = 'https://signin.aws.amazon.com/oauth?Action=logout';
             } else if (accountTypeID == '2') {
                 // govcloud
-                logout_iframe.src = 'https://signin.amazonaws-us-gov.com/oauth?Action=logout';
+                logoutURL = 'https://signin.amazonaws-us-gov.com/oauth?Action=logout';
             } else if (accountTypeID == '4') {
-                logout_iframe.src = 'http://signin.c2shome.ic.gov/oauth?Action=logout';
+                logoutURL = 'http://signin.c2shome.ic.gov/oauth?Action=logout';
             } else if (accountTypeID == '5') {
-                logout_iframe.src = 'http://signin.sc2shome.sgov.gov/oauth?Action=logout';
+                logoutURL = 'http://signin.sc2shome.sgov.gov/oauth?Action=logout';
             }
-            logout_iframe.onload = () => {
-              callbackClose()
-              window.location.replace(redirectURL);
+            if (agent.includes('Firefox')) {
+              // popup blocked by default, user must allow
+              let tab = window.open(logoutURL, '_blank')
+              setTimeout(() => {
+                callbackClose()
+                tab.location.replace(redirectURL);
+                window.close()
+              }, 500);
+            } else {
+              const logout_iframe = document.createElement('iframe');
+              logout_iframe.height = '0';
+              logout_iframe.width = '0';
+              logout_iframe.src = logoutURL;
+              logout_iframe.onload = () => {
+                callbackClose()
+                window.location.replace(redirectURL);
+              }
+              document.body.appendChild(logout_iframe);
             }
-            document.body.appendChild(logout_iframe);
           }
         </script>
       </head>


### PR DESCRIPTION
This PR adds browser agent detection and if in Firefox handles AWS console session logout via tabs vs iframes.

Closes #29 