### PR TITLE
Update console federation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,18 @@ Notes for upgrading...
 
 ### Changed
 
-- Federating into the web console is now handled without iframes or javascript [kionsoftware/kion-cli/pull/40]
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+[0.2.1] - 2024-05-30
+--------------------
+
+### Changed
+
+- Federating into the web console is now handled without iframes or javascript [kionsoftware/kion-cli/pull/40]
 
 [0.2.0] - 2024-05-24
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Notes for upgrading...
 
 ### Changed
 
+- Federating into the web console is now handled without iframes or javascript [kionsoftware/kion-cli/pull/40]
+
 ### Deprecated
 
 ### Removed

--- a/lib/helper/browser.go
+++ b/lib/helper/browser.go
@@ -158,6 +158,8 @@ func redirectServer(url string, typeID uint) {
 // OpenBrowser opens up a URL in the users system default browser. It uses a
 // local webserver to host a page that handles logging users out of existing
 // sessions then redirecting to the federated login page.
+//
+// Deprecated: Use OpenBrowserRedirect instead.
 func OpenBrowser(url string, typeID uint) error {
 	var err error
 

--- a/lib/helper/browser.go
+++ b/lib/helper/browser.go
@@ -155,7 +155,9 @@ func redirectServer(url string, typeID uint) {
 	log.Fatal(server.ListenAndServe())
 }
 
-// OpenBrowser opens up a URL in the users system default browser.
+// OpenBrowser opens up a URL in the users system default browser. It uses a
+// local webserver to host a page that handles logging users out of existing
+// sessions then redirecting to the federated login page.
 func OpenBrowser(url string, typeID uint) error {
 	var err error
 
@@ -182,7 +184,10 @@ func OpenBrowser(url string, typeID uint) error {
 	return err
 }
 
-func OpenBrowserDirect(target string, typeID uint) error {
+// OpenBrowserDirect opens up a URL in the users system default browser. It
+// uses the redirect_uri query parameter to handle the logout and redirect to
+// the federated login page.
+func OpenBrowserRedirect(target string, typeID uint) error {
 	var err error
 	var logoutURL string
 	var replacement string

--- a/main.go
+++ b/main.go
@@ -542,7 +542,7 @@ func favorites(cCtx *cli.Context) error {
 			return err
 		}
 		fmt.Printf("Federating into %s (%s) via %s\n", favorite.Name, favorite.Account, car.AwsIamRoleName)
-		return helper.OpenBrowser(url, car.AccountTypeID)
+		return helper.OpenBrowserDirect(url, car.AccountTypeID)
 	} else {
 		// placeholder for our stak
 		var stak kion.STAK
@@ -625,7 +625,7 @@ func fedConsole(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return helper.OpenBrowser(url, car.AccountTypeID)
+	return helper.OpenBrowserDirect(url, car.AccountTypeID)
 }
 
 // listFavorites prints out the users stored favorites. Extra information is

--- a/main.go
+++ b/main.go
@@ -825,7 +825,7 @@ func main() {
 		////////////////
 
 		Name:                 "Kion CLI",
-		Version:              "v0.2.0",
+		Version:              "v0.2.1",
 		Usage:                "Kion federation on the command line!",
 		EnableBashCompletion: true,
 		Before:               beforeCommands,

--- a/main.go
+++ b/main.go
@@ -542,7 +542,7 @@ func favorites(cCtx *cli.Context) error {
 			return err
 		}
 		fmt.Printf("Federating into %s (%s) via %s\n", favorite.Name, favorite.Account, car.AwsIamRoleName)
-		return helper.OpenBrowserDirect(url, car.AccountTypeID)
+		return helper.OpenBrowserRedirect(url, car.AccountTypeID)
 	} else {
 		// placeholder for our stak
 		var stak kion.STAK
@@ -625,7 +625,7 @@ func fedConsole(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return helper.OpenBrowserDirect(url, car.AccountTypeID)
+	return helper.OpenBrowserRedirect(url, car.AccountTypeID)
 }
 
 // listFavorites prints out the users stored favorites. Extra information is


### PR DESCRIPTION
This PR utilizes the `redirect_uri` query parameter to handle closing out existing AWS web console sessions then automatically redirecting to the new federated session. This bypasses the need for logging out via iframes or tab manipulation via javascript. Thanks @sculliga for the intel!

Closes #35 