### PR TITLE
Add config file override and profiles support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Notes for upgrading...
 
 ### Added
 
+- Users can now set a custom config file with the `KION_CONFIG` environment variable [kionsoftware/kion-cli/pull/42]
+- Users can define profiles to use Kion CLI with multiple Kion instances [kionsoftware/kion-cli/pull/42]
+
 ### Changed
 
 ### Deprecated
@@ -19,6 +22,8 @@ Notes for upgrading...
 ### Removed
 
 ### Fixed
+
+- Corrected an issue where the Kion CLI configuration file was not actually optional [kionsoftware/kion-cli/pull/42]
 
 [0.2.1] - 2024-05-30
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,54 @@ Notes for upgrading...
 
 ### Added
 
-- Users can now set a custom config file with the `KION_CONFIG` environment variable [kionsoftware/kion-cli/pull/42]
-- Users can define profiles to use Kion CLI with multiple Kion instances [kionsoftware/kion-cli/pull/42]
-- Created a `util` command and `flush-cache` subcommand to flush the cache [kionsoftware/kion-cli/pull/42]
-
 ### Changed
 
 ### Deprecated
 
 ### Removed
+
+### Fixed
+
+[0.3.0] - 2024-06-03
+--------------------
+
+You can now use Kion CLI with multiple instances of Kion through the use of configuration profiles or by pointing to alternate configuration files. Here are some usage examples:
+
+```bash
+# point to another configuration file
+KION_CONFIG=~/.kion.development.yml kion stak
+
+# use a 'development' profile within your ~/.kion.yml configuration file
+kion --profile development fav sandbox
+```
+
+An configuration file for the profile usage example above would look something like this:
+
+```yaml
+kion:
+  url: https://kion.mycompany.com
+  api_key: "app_123"
+favorites:
+  - name: production
+    account: "232323232323"
+    cloud_access_role: ReadOnly
+
+profiles:
+  development:
+    kion:
+      url: https://dev.kion.mycompany.com
+      api_key: "app_abc"
+    favorites:
+      - name: sandbox
+        account: "121212121212"
+        cloud_access_role: Admin
+```
+
+### Added
+
+- Users can now set a custom config file with the `KION_CONFIG` environment variable [kionsoftware/kion-cli/pull/42]
+- Users can define profiles to use Kion CLI with multiple Kion instances [kionsoftware/kion-cli/pull/42]
+- Created a `util` command and `flush-cache` subcommand to flush the cache [kionsoftware/kion-cli/pull/42]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Notes for upgrading...
 
 - Users can now set a custom config file with the `KION_CONFIG` environment variable [kionsoftware/kion-cli/pull/42]
 - Users can define profiles to use Kion CLI with multiple Kion instances [kionsoftware/kion-cli/pull/42]
+- Created a `util` command and `flush-cache` subcommand to flush the cache [kionsoftware/kion-cli/pull/42]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ KION_CONFIG=~/.kion.development.yml kion stak
 kion --profile development fav sandbox
 ```
 
-An configuration file for the profile usage example above would look something like this:
+A configuration file for the profile usage example above would look something like this:
 
 ```yaml
+# default profile if none specified
 kion:
   url: https://kion.mycompany.com
   api_key: "app_123"
@@ -44,6 +45,7 @@ favorites:
     account: "232323232323"
     cloud_access_role: ReadOnly
 
+# alternate profiles called with the global `--profile [name]` flag
 profiles:
   development:
     kion:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ console, con, c    Federate into the cloud service provider console.
 
 run                Run a command with short-term access keys
 
+util               Tools for managing Kion CLI.
+
 help, h            Print usage text.
 
 
@@ -277,6 +279,14 @@ OPTIONS
   --region val, -r val                 Specify which region to target.
 
   --help, -h                           Print usage text.
+```
+
+__Util Commands:__
+
+```text
+SUB COMMANDS
+
+  flush-cache                          Clear out all cache entries for the Kion CLI.
 ```
 
 __Environment:__

--- a/README.md
+++ b/README.md
@@ -68,7 +68,34 @@ Setup
       - name: prod
         account: "111122224444"
         cloud_access_role: ReadOnly
+    profiles:
+      dev:
+        kion:
+          url: https://dev.mykion.example
+          api_key: [api key]
+          username:
+          password:
+          idms_id:
+          saml_metadata_file:
+          saml_sp_issuer:
+          disable_cache:
+        favorites:
+          - name: sandbox
+            account: 212121212121
+            cloud_access_role: Dev
+      test:
+        kion:
+          url: http://test.mykion.example
+          api_key: [api key]
+          username:
+          password:
+          idms_id:
+          saml_metadata_file:
+          saml_sp_issuer:
+          disable_cache:
     ```
+
+    You can also point Kion CLI to another configuration file by setting the `KION_CONFIG` environment variable to the desired path.
 
 4. Usage examples:
 
@@ -173,6 +200,10 @@ __Global Options:__
 
 --disable-cache                        Disable the use of cache for Kion CLI.
 
+--profile PROFILE                      Use the specified PROFILE from the Kion CLI
+                                       configuration file. If no profile is specified
+                                       the default will be used.
+
 --help, -h                             Print usage text.
 
 --version, -v                          Print the Kion CLI version.
@@ -256,6 +287,9 @@ Kion CLI follows standard precedence for defining configurations:
   `Flag > Environment Variable > Configuration File > Default Value`
 
 ```text
+KION_CONFIG              Path to the Kion CLI configuration file.
+                         Defaults to `~/.kion.yml`
+
 KION_URL                 URL of the Kion instance to interact with.
 
 KION_USERNAME            Username used for authenticating with Kion.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Setup
 3. (optional) Create a configuration file in your home directory named `.kion.yml`:
 
     ```yaml
+    ################################################################################
+    ##                                                                            ##
+    ##  Default Profile                                                           ##
+    ##                                                                            ##
+    ################################################################################
+
     kion:
       url: https://mykion.example
       api_key: [api key]
@@ -68,6 +74,13 @@ Setup
       - name: prod
         account: "111122224444"
         cloud_access_role: ReadOnly
+
+    ################################################################################
+    ##                                                                            ##
+    ##  Alternate Profiles                                                        ##
+    ##                                                                            ##
+    ################################################################################
+
     profiles:
       dev:
         kion:

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -11,6 +11,7 @@ type Cache interface {
 	GetStak(key string) (kion.STAK, bool, error)
 	SetSession(value kion.Session) error
 	GetSession() (kion.Session, bool, error)
+	FlushCache() error
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/cache/helpers-cache.go
+++ b/lib/cache/helpers-cache.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"encoding/json"
+
+	"github.com/99designs/keyring"
+)
+
+// flushCache clears the Kion CLI cache.
+func flushCache(k keyring.Keyring) error {
+	// marshal an empty cache to json
+	var cacheData CacheData
+	data, err := json.Marshal(cacheData)
+	if err != nil {
+		return err
+	}
+
+	// build the keyring item
+	cacheName := "Kion-CLI Cache"
+	cache := keyring.Item{
+		Key:         cacheName,
+		Data:        data,
+		Label:       cacheName,
+		Description: "Cache data for the Kion-CLI.",
+	}
+
+	// store the cache
+	err = k.Set(cache)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Real Cacher                                                               //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FLushCache implements the FlushCache interface for RealCache.
+func (c *RealCache) FlushCache() error {
+	return flushCache(c.keyring)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Null Cacher                                                               //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FLushCache implements the FlushCache interface for NullCache.
+func (c *NullCache) FlushCache() error {
+	return flushCache(c.keyring)
+}

--- a/lib/cache/session-cache.go
+++ b/lib/cache/session-cache.go
@@ -9,7 +9,7 @@ import (
 
 // SetSession is a common func for all Cache implementations and stores a
 // Session in the cache.
-func SetSession(k keyring.Keyring, session kion.Session) error {
+func setSession(k keyring.Keyring, session kion.Session) error {
 	// pull our stak cache
 	cacheName := "Kion-CLI Cache"
 	cache, err := k.Get(cacheName)
@@ -55,7 +55,7 @@ func SetSession(k keyring.Keyring, session kion.Session) error {
 
 // GetSession is a common func for all Cache implementations and retrieves a
 // Session in the cache.
-func GetSession(k keyring.Keyring) (kion.Session, bool, error) {
+func getSession(k keyring.Keyring) (kion.Session, bool, error) {
 	// pull our stak cache
 	cache, err := k.Get("Kion-CLI Cache")
 	if err != nil {
@@ -93,13 +93,13 @@ func GetSession(k keyring.Keyring) (kion.Session, bool, error) {
 // SetSession implements the Cache interface for RealCache and wraps a common
 // function for storing session data.
 func (c *RealCache) SetSession(session kion.Session) error {
-	return SetSession(c.keyring, session)
+	return setSession(c.keyring, session)
 }
 
 // GetSession implements the Cache interface for RealCache and wraps a common
 // function for retrieving session data.
 func (c *RealCache) GetSession() (kion.Session, bool, error) {
-	return GetSession(c.keyring)
+	return getSession(c.keyring)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -111,11 +111,11 @@ func (c *RealCache) GetSession() (kion.Session, bool, error) {
 // SetSession implements the Cache interface for NullCache and wraps a common
 // function for storing session data.
 func (c *NullCache) SetSession(session kion.Session) error {
-	return SetSession(c.keyring, session)
+	return setSession(c.keyring, session)
 }
 
 // GetSession implements the Cache interface for NullCache and wraps a common
 // function for retrieving session data.
 func (c *NullCache) GetSession() (kion.Session, bool, error) {
-	return GetSession(c.keyring)
+	return getSession(c.keyring)
 }

--- a/lib/kion/kion.go
+++ b/lib/kion/kion.go
@@ -70,11 +70,11 @@ func runQuery(method string, url string, token string, query map[string]string, 
 ////////////////////////////////////////////////////////////////////////////////
 
 // GetVersion returns the targeted Kion's version number.
-func GetVersion(host string, token string) (string, error) {
+func GetVersion(host string) (string, error) {
 	url := fmt.Sprintf("%v/api/version", host)
 	query := map[string]string{}
 	var data interface{}
-	resp, _, err := runQuery("GET", url, token, query, data)
+	resp, _, err := runQuery("GET", url, "", query, data)
 	if err != nil {
 		return "", err
 	}

--- a/lib/structs/configuraton-structs.go
+++ b/lib/structs/configuraton-structs.go
@@ -9,8 +9,9 @@ package structs
 // Configuration holds the CLI tool values needed to run. The struct maps to
 // the applications configured dotfile for persistence between sessions.
 type Configuration struct {
-	Kion      Kion       `yaml:"kion"`
-	Favorites []Favorite `yaml:"favorites"`
+	Kion      Kion               `yaml:"kion"`
+	Favorites []Favorite         `yaml:"favorites"`
+	Profiles  map[string]Profile `yaml:"profiles"`
 }
 
 // Kion holds information about the instance of Kion with which the application
@@ -34,4 +35,10 @@ type Favorite struct {
 	CAR        string `yaml:"cloud_access_role"`
 	AccessType string `yaml:"access_type"`
 	Region     string `yaml:"region"`
+}
+
+// Profile holds an alternate configuration for Kion and Favorites.
+type Profile struct {
+	Kion      Kion       `yaml:"kion"`
+	Favorites []Favorite `yaml:"favorites"`
 }

--- a/main.go
+++ b/main.go
@@ -288,6 +288,12 @@ func setAuthToken(cCtx *cli.Context) error {
 // beforeCommands run after the context is ready but before any subcommands are
 // executed. Currently used to test feature compatibility with targeted Kion.
 func beforeCommands(cCtx *cli.Context) error {
+	// skip before bits if we don't need them (ie we're just printing help)
+	args := cCtx.Args().Slice()
+	if len(args) == 0 || args[0] == "help" || args[0] == "h" {
+		return nil
+	}
+
 	// grab the kion url if not already set
 	err := setEndpoint()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -774,13 +774,19 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// set global for config path
-	configPath = filepath.Join(home, configFile)
+	// allow config file to be overridden by an env var, else use default
+	userConfigFile := os.Getenv("KION_CONFIG")
+	if userConfigFile != "" {
+		configPath = filepath.Clean(userConfigFile)
+	} else {
+		configPath = filepath.Join(home, configFile)
+	}
 
 	// load configuration file
 	err = helper.LoadConfig(configPath, &config)
-	if err != nil {
-		log.Fatal(err)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		color.Red(" Error: %v", err)
+		os.Exit(1)
 	}
 
 	// prep default text for password

--- a/main.go
+++ b/main.go
@@ -883,7 +883,7 @@ func main() {
 		////////////////
 
 		Name:                 "Kion CLI",
-		Version:              "v0.2.1",
+		Version:              "v0.3.0",
 		Usage:                "Kion federation on the command line!",
 		EnableBashCompletion: true,
 		Before:               beforeCommands,

--- a/main.go
+++ b/main.go
@@ -292,7 +292,7 @@ func setAuthToken(cCtx *cli.Context) error {
 // executed. Currently used to test feature compatibility with targeted Kion.
 func beforeCommands(cCtx *cli.Context) error {
 	// gather the targeted kion version
-	kionVer, err := kion.GetVersion(cCtx.String("endpoint"), cCtx.String("token"))
+	kionVer, err := kion.GetVersion(config.Kion.Url)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -799,7 +799,7 @@ func main() {
 	samlMetadataFile := config.Kion.SamlMetadataFile
 	if samlMetadataFile != "" && !strings.HasPrefix(samlMetadataFile, "http") {
 		if !filepath.IsAbs(samlMetadataFile) {
-			// Resolve the file path relative to the config path, which is the home directory
+			// resolve the file path relative to the config path, which is the home directory
 			samlMetadataFile = filepath.Join(filepath.Dir(configPath), samlMetadataFile)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -288,6 +288,12 @@ func setAuthToken(cCtx *cli.Context) error {
 // beforeCommands run after the context is ready but before any subcommands are
 // executed. Currently used to test feature compatibility with targeted Kion.
 func beforeCommands(cCtx *cli.Context) error {
+	// grab the kion url if not already set
+	err := setEndpoint()
+	if err != nil {
+		return err
+	}
+
 	// gather the targeted kion version
 	kionVer, err := kion.GetVersion(config.Kion.Url)
 	if err != nil {
@@ -351,22 +357,6 @@ func beforeCommands(cCtx *cli.Context) error {
 	return nil
 }
 
-// authCommand prompts for authentication as needed and ensures an auth token
-// is set.
-func authCommand(cCtx *cli.Context) error {
-	// run prompts for any missing items
-	err := setEndpoint(cCtx)
-	if err != nil {
-		return err
-	}
-	err = setAuthToken(cCtx)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // genStaks generates short term access keys by walking users through an
 // interactive prompt. Short term access keys are either printed to stdout or a
 // sub-shell is created with them set in the environment.
@@ -421,7 +411,7 @@ func genStaks(cCtx *cli.Context) error {
 		// grab the car if needed
 		if getCar {
 			// handle auth
-			err := authCommand(cCtx)
+			err := setAuthToken(cCtx)
 			if err != nil {
 				return err
 			}
@@ -433,7 +423,7 @@ func genStaks(cCtx *cli.Context) error {
 		}
 	} else {
 		// handle auth
-		err := authCommand(cCtx)
+		err := setAuthToken(cCtx)
 		if err != nil {
 			return err
 		}
@@ -459,7 +449,7 @@ func genStaks(cCtx *cli.Context) error {
 	// grab a new stak if needed
 	if stak == (kion.STAK{}) {
 		// handle auth
-		err := authCommand(cCtx)
+		err := setAuthToken(cCtx)
 		if err != nil {
 			return err
 		}
@@ -519,7 +509,7 @@ func favorites(cCtx *cli.Context) error {
 	// determine favorite action, default to cli unless explicitly set to web
 	if favorite.AccessType == "web" {
 		// handle auth
-		err = authCommand(cCtx)
+		err = setAuthToken(cCtx)
 		if err != nil {
 			return err
 		}
@@ -568,7 +558,7 @@ func favorites(cCtx *cli.Context) error {
 			stak = cachedSTAK
 		} else {
 			// handle auth
-			err = authCommand(cCtx)
+			err = setAuthToken(cCtx)
 			if err != nil {
 				return err
 			}
@@ -605,7 +595,7 @@ func favorites(cCtx *cli.Context) error {
 // role in the users default browser.
 func fedConsole(cCtx *cli.Context) error {
 	// handle auth
-	err := authCommand(cCtx)
+	err := setAuthToken(cCtx)
 	if err != nil {
 		return err
 	}
@@ -697,7 +687,7 @@ func runCommand(cCtx *cli.Context) error {
 			stak = cachedSTAK
 		} else {
 			// handle auth
-			err := authCommand(cCtx)
+			err := setAuthToken(cCtx)
 			if err != nil {
 				return err
 			}
@@ -737,7 +727,7 @@ func runCommand(cCtx *cli.Context) error {
 			stak = cachedSTAK
 		} else {
 			// handle auth
-			err := authCommand(cCtx)
+			err := setAuthToken(cCtx)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -809,6 +809,11 @@ func runCommand(cCtx *cli.Context) error {
 	return nil
 }
 
+// flushCache clears the Kion CLI cache.
+func flushCache(cCtx *cli.Context) error {
+	return c.FlushCache()
+}
+
 // afterCommands run after any subcommands are executed.
 func afterCommands(cCtx *cli.Context) error {
 	return nil
@@ -1072,6 +1077,17 @@ func main() {
 						Name:    "region",
 						Aliases: []string{"r"},
 						Usage:   "target region",
+					},
+				},
+			},
+			{
+				Name:  "util",
+				Usage: "Utility commands",
+				Subcommands: []*cli.Command{
+					{
+						Name:   "flush-cache",
+						Usage:  "Flush the Kion CLI cache",
+						Action: flushCache,
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -44,16 +44,13 @@ var (
 // setEndpoint sets the target Kion installation to interact with. If not
 // passed to the tool as an argument, set in the env, or present in the
 // configuration dotfile it will prompt the user to provide it.
-func setEndpoint(cCtx *cli.Context) error {
-	if cCtx.Value("endpoint") == "" {
+func setEndpoint() error {
+	if config.Kion.Url == "" {
 		kionURL, err := helper.PromptInput("Kion URL:")
 		if err != nil {
 			return err
 		}
-		err = cCtx.Set("endpoint", kionURL)
-		if err != nil {
-			return err
-		}
+		config.Kion.Url = kionURL
 	}
 	return nil
 }
@@ -68,7 +65,7 @@ func AuthUNPW(cCtx *cli.Context) error {
 
 	// prompt idms if needed
 	if idmsID == 0 {
-		idmss, err := kion.GetIDMSs(cCtx.String("endpoint"))
+		idmss, err := kion.GetIDMSs(config.Kion.Url)
 		if err != nil {
 			return err
 		}
@@ -101,7 +98,7 @@ func AuthUNPW(cCtx *cli.Context) error {
 	}
 
 	// auth and capture our session
-	session, err := kion.Authenticate(cCtx.String("endpoint"), idmsID, un, pw)
+	session, err := kion.Authenticate(config.Kion.Url, idmsID, un, pw)
 	if err != nil {
 		return err
 	}
@@ -153,7 +150,7 @@ func AuthSAML(cCtx *cli.Context) error {
 	}
 
 	authData, err := kion.AuthenticateSAML(
-		cCtx.String("endpoint"),
+		config.Kion.Url,
 		samlMetadata,
 		samlServiceProviderIssuer)
 	if err != nil {
@@ -218,7 +215,7 @@ func setAuthToken(cCtx *cli.Context) error {
 			// if refreshExp.After(now) {
 			// 	un := session.UserName
 			// 	idmsId := session.IDMSID
-			// 	session, err = kion.Authenticate(cCtx.String("endpoint"), idmsId, un, session.Refresh.Token)
+			// 	session, err = kion.Authenticate(config.Kion.Url, idmsId, un, session.Refresh.Token)
 			// 	if err != nil {
 			// 		return err
 			// 	}
@@ -345,7 +342,7 @@ func beforeCommands(cCtx *cli.Context) error {
 	}
 
 	// initialize the cache
-	if cCtx.Bool("disable-cache") {
+	if config.Kion.DisableCache {
 		c = cache.NewNullCache(ring)
 	} else {
 		c = cache.NewCache(ring)
@@ -379,7 +376,7 @@ func genStaks(cCtx *cli.Context) error {
 	var stak kion.STAK
 
 	// set vars for easier access
-	endpoint := cCtx.String("endpoint")
+	endpoint := config.Kion.Url
 	carName := cCtx.String("car")
 	account := cCtx.String("account")
 	cacheKey := fmt.Sprintf("%s-%s", carName, account)
@@ -529,15 +526,15 @@ func favorites(cCtx *cli.Context) error {
 
 		var car kion.CAR
 		// attempt to find exact match then fallback to first match
-		car, err = kion.GetCARByNameAndAccount(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
+		car, err = kion.GetCARByNameAndAccount(config.Kion.Url, cCtx.String("token"), favorite.CAR, favorite.Account)
 		if err != nil {
-			car, err = kion.GetCARByName(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR)
+			car, err = kion.GetCARByName(config.Kion.Url, cCtx.String("token"), favorite.CAR)
 			if err != nil {
 				return err
 			}
 			car.AccountNumber = favorite.Account
 		}
-		url, err := kion.GetFederationURL(cCtx.String("endpoint"), cCtx.String("token"), car)
+		url, err := kion.GetFederationURL(config.Kion.Url, cCtx.String("token"), car)
 		if err != nil {
 			return err
 		}
@@ -577,7 +574,7 @@ func favorites(cCtx *cli.Context) error {
 			}
 
 			// grab a new stak
-			stak, err = kion.GetSTAK(cCtx.String("endpoint"), cCtx.String("token"), favorite.CAR, favorite.Account)
+			stak, err = kion.GetSTAK(config.Kion.Url, cCtx.String("token"), favorite.CAR, favorite.Account)
 			if err != nil {
 				return err
 			}
@@ -621,7 +618,7 @@ func fedConsole(cCtx *cli.Context) error {
 	}
 
 	// grab the csp federation url
-	url, err := kion.GetFederationURL(cCtx.String("endpoint"), cCtx.String("token"), car)
+	url, err := kion.GetFederationURL(config.Kion.Url, cCtx.String("token"), car)
 	if err != nil {
 		return err
 	}
@@ -659,7 +656,7 @@ func listFavorites(cCtx *cli.Context) error {
 // provided command with said credentials set.
 func runCommand(cCtx *cli.Context) error {
 	// set vars for easier access
-	endpoint := cCtx.String("endpoint")
+	endpoint := config.Kion.Url
 	favName := cCtx.String("favorite")
 	accNum := cCtx.String("account")
 	carName := cCtx.String("car")

--- a/main.go
+++ b/main.go
@@ -332,6 +332,8 @@ func beforeCommands(cCtx *cli.Context) error {
 		if found {
 			config.Kion = profile.Kion
 			config.Favorites = profile.Favorites
+		} else {
+			return fmt.Errorf("profile not found: %s", profileName)
 		}
 
 		// honor any global flags that were set to maintain precedence


### PR DESCRIPTION
Allow users to point to another Kion CLI configuration file by setting the `KION_CONFIG` environment variable. Also add support for defining profiles within the configuration file. When setting a profile, any additionally passed flags will override any settings within the selected profile to maintain precedence `Flag > Environment Variable > Configuration File > Default Value`.

Closes #41 