### PR TITLE
kion-cli doesn't use default keyring on Gnome Wallet (libsecret)

### DIFF
--- a/main.go
+++ b/main.go
@@ -411,6 +411,9 @@ func beforeCommands(cCtx *cli.Context) error {
 		KWalletAppID:  name,
 		KWalletFolder: name,
 
+		// gnome wallet (libsecret)
+		LibSecretCollectionName: "login",
+
 		// windows
 		WinCredPrefix: name,
 


### PR DESCRIPTION
Updating 99designs/keyring config for Gnome Wallet (libsecret) to use default keyring instead of creating a new one for kion-cli