### PR TITLE
Adding encrypted storage for login passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ KION_URL                 URL of the Kion instance to interact with.
 
 KION_USERNAME            Username used for authenticating with Kion.
 
-KION_PASSWORD            Passwrod used for authenticating with Kion.
+KION_PASSWORD            Password used for authenticating with Kion.
 
 KION_IDMS_ID             IDMS ID with which to authenticate if using username and
                          password. If only one IDMS is configured that uses username and
@@ -363,6 +363,8 @@ PROFILES
 profiles[NAME].KION                An instance of KION as defined above.
 profiles[NAME].FAVORITES           An instance of FAVORITES as defined above.
 ```
+
+Note: if the authentication password is not provided as a Flag / Environment Variable / Configuration file entry, kion will prompt for the password on the command line. Kion will cache this password in the system keychain's encrypted storage. This may be preferable in environments where plaintext storage of credentials is frowned upon.
 
 __Caching:__
 

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -11,6 +11,8 @@ type Cache interface {
 	GetStak(carName string, accNum string, accAlias string) (kion.STAK, bool, error)
 	SetSession(value kion.Session) error
 	GetSession() (kion.Session, bool, error)
+	SetPassword(host string, idmsID uint, un string, pw string) error
+	GetPassword(host string, idmsID uint, un string) (string, bool, error)
 	FlushCache() error
 }
 
@@ -27,8 +29,9 @@ type RealCache struct {
 
 // CacheData is a nested structure for storing kion-cli data.
 type CacheData struct {
-	STAK    map[string]kion.STAK
-	SESSION kion.Session
+	STAK     map[string]kion.STAK
+	SESSION  kion.Session
+	PASSWORD map[string]string
 }
 
 // NewCache creates a new RealCache.

--- a/lib/cache/password-cache.go
+++ b/lib/cache/password-cache.go
@@ -1,0 +1,120 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/99designs/keyring"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Real Cacher                                                               //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// SetPassword stores a Password in the cache (or removes it if the password is nil).
+func (c *RealCache) SetPassword(host string, idmsID uint, un string, pw string) error {
+	// set the key based on what was passed
+	key := fmt.Sprintf("%s-%d-%s", host, idmsID, un)
+
+	// pull our cache
+	cacheName := "Kion-CLI Cache"
+	cache, err := c.keyring.Get(cacheName)
+	if err != nil && err != keyring.ErrKeyNotFound {
+		return err
+	}
+
+	// unmarshal the json data
+	var cacheData CacheData
+	if len(cache.Data) > 0 {
+		err = json.Unmarshal(cache.Data, &cacheData)
+		if err != nil {
+			return err
+		}
+	}
+
+	// initialize the map if it is still nil
+	if cacheData.PASSWORD == nil {
+		cacheData.PASSWORD = make(map[string]string)
+	}
+
+	if pw != "" {
+		// create/update our entry
+		cacheData.PASSWORD[key] = pw
+	} else {
+		// Delete the entry
+		delete(cacheData.PASSWORD, key)
+	}
+
+	// marshal the stack cache to json
+	data, err := json.Marshal(cacheData)
+	if err != nil {
+		return err
+	}
+
+	// build the keyring item
+	cache = keyring.Item{
+		Key:         cacheName,
+		Data:        data,
+		Label:       cacheName,
+		Description: "Cache data for the Kion-CLI.",
+	}
+
+	// store the cache
+	err = c.keyring.Set(cache)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetPassword retrieves a password from the cache.
+func (c *RealCache) GetPassword(host string, idmsID uint, un string) (string, bool, error) {
+	// set the key based on what was passed
+	key := fmt.Sprintf("%s-%d-%s", host, idmsID, un)
+
+	// pull our cache
+	cache, err := c.keyring.Get("Kion-CLI Cache")
+	if err != nil {
+		if err == keyring.ErrKeyNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	// unmarshal the json data
+	var cacheData CacheData
+	if len(cache.Data) > 0 {
+		err = json.Unmarshal(cache.Data, &cacheData)
+		if err != nil {
+			return "", false, err
+		}
+	}
+
+	// return the password if found
+	password, found := cacheData.PASSWORD[key]
+	if found {
+		return password, true, nil
+	}
+
+	// return empty password if not found
+	return "", false, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Null Cacher                                                               //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// SetPassword does nothing.
+func (c *NullCache) SetPassword(host string, idmsID uint, un string, pw string) error {
+	return nil
+}
+
+// GetPassword returns an empty password, false, and a nil error.
+func (c *NullCache) GetPassword(host string, idmsID uint, un string) (string, bool, error) {
+	return "", false, nil
+}

--- a/main.go
+++ b/main.go
@@ -117,7 +117,12 @@ func AuthUNPW(cCtx *cli.Context) error {
 		// failues). Conservatively clear out any cached password when
 		// Authenticate() fails
 		if pwFoundInCache {
-			c.SetPassword(config.Kion.Url, idmsID, un, "")
+			err2 := c.SetPassword(config.Kion.Url, idmsID, un, "")
+			if err2 != nil {
+				// We're already handling the error stored in err, logging err2
+				// is the best we can do
+				log.Printf("Failed to clear cached password after authentication failure: %v", err2)
+			}
 		}
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -92,21 +92,44 @@ func AuthUNPW(cCtx *cli.Context) error {
 	}
 
 	// prompt password if needed
+	pwFoundInCache := false
 	if pw == "" {
-		pw, err = helper.PromptPassword("Password:")
+		// Check password cache
+		pw, pwFoundInCache, err = c.GetPassword(config.Kion.Url, idmsID, un)
 		if err != nil {
 			return err
+		}
+
+		if !pwFoundInCache {
+			pw, err = helper.PromptPassword("Password:")
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	// auth and capture our session
 	session, err := kion.Authenticate(config.Kion.Url, idmsID, un, pw)
 	if err != nil {
+		// Unfortunately, the remote auth endpoint doesn't provide an easy way
+		// of determining if an auth error was the cause of failure (it returns
+		// an HTTP 400 with a body that contains a message about authentication
+		// failues). Conservatively clear out any cached password when
+		// Authenticate() fails
+		if pwFoundInCache {
+			c.SetPassword(config.Kion.Url, idmsID, un, "")
+		}
 		return err
 	}
 	session.IDMSID = idmsID
 	session.UserName = un
 	err = c.SetSession(session)
+	if err != nil {
+		return err
+	}
+
+	// if auth succeeded, cache the password
+	err = c.SetPassword(config.Kion.Url, idmsID, un, pw)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -117,11 +117,11 @@ func AuthUNPW(cCtx *cli.Context) error {
 		// failues). Conservatively clear out any cached password when
 		// Authenticate() fails
 		if pwFoundInCache {
-			err2 := c.SetPassword(config.Kion.Url, idmsID, un, "")
-			if err2 != nil {
-				// We're already handling the error stored in err, logging err2
+			err := c.SetPassword(config.Kion.Url, idmsID, un, "")
+			if err != nil {
+				// We're already handling another error, logging
 				// is the best we can do
-				log.Printf("Failed to clear cached password after authentication failure: %v", err2)
+				color.Red("Failed to clear password from cache, %v", err)
 			}
 		}
 		return err


### PR DESCRIPTION
This PR provides a way to have login passwords stored in encrypted storage (eg the system keyring) rather than the current options of 
a) re-typing them when establishing each new session, or 
b) stashing them in plaintext in .kion.yml (or env vars which are typically populated from plaintext scripts)