### PR TITLE
Exit non-zero if error is present, resolves #63

### DIFF
--- a/main.go
+++ b/main.go
@@ -1210,5 +1210,6 @@ func main() {
 	// run the app
 	if err := app.Run(os.Args); err != nil {
 		color.Red(" Error: %v", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Exit with a non-zero exit code if an error bubbles up.

Resolves #63 