### PR TITLE
Pull and set HISTFILE when starting zsh sub-shell

### DIFF
--- a/lib/helper/shell.go
+++ b/lib/helper/shell.go
@@ -36,6 +36,7 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 	// get users shell information
 	usrShellPath := os.Getenv("SHELL")
 	usrShellName := filepath.Base(usrShellPath)
+	usrHistFile := os.Getenv("HISTFILE")
 
 	// create command based on the users shell and set prompt
 	var cmd string
@@ -50,7 +51,7 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(f, `source $HOME/.zshrc; autoload -U colors && colors; export PS1="%%F{green}[%v]%%b%%f $PS1"`, accountMeta)
+		fmt.Fprintf(f, `HISTFILE=%s; source $HOME/.zshrc; autoload -U colors && colors; export PS1="%%F{green}[%v]%%b%%f $PS1"`, usrHistFile, accountMeta)
 		err = f.Sync()
 		if err != nil {
 			return err


### PR DESCRIPTION
Implementing suggestion from #69. Sets the `HISTFILE` variable when starting up a sub-shell to ensure the users history is available as well as is tracked within the sub-shell.

@joraff for awareness.