### PR TITLE
Firefox containers (Windows, Linux, MacOS), and Windows sub-shells support

### DIFF
--- a/lib/helper/shell.go
+++ b/lib/helper/shell.go
@@ -73,7 +73,7 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 		// cmd = fmt.Sprintf(`cmd.exe /K "PROMPT [%s]$G"`, accountMeta)
 		// shell = exec.Command("cmd.exe", "/C", "start", cmd)
 		cmdPath := "C:\\Windows\\System32\\cmd.exe"
-		shell = exec.Command(cmdPath, "/K", fmt.Sprintf(`PROMPT [%s]$G`, accountMeta))
+		shell = exec.Command(cmdPath, "/K", fmt.Sprintf(`PROMPT $E[32m[%s]$E[0m$G`, accountMeta))
 	} else {
 		shell = exec.Command("bash", "-c", cmd)
 	}

--- a/lib/helper/shell.go
+++ b/lib/helper/shell.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -29,7 +30,11 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 		accountMeta = accountNumber
 		accountMetaSentence = accountNumber
 	} else {
-		accountMeta = fmt.Sprintf("%v|%v", accountAlias, accountNumber)
+		if runtime.GOOS == "windows" {
+			accountMeta = fmt.Sprintf("%v^|%v", accountAlias, accountNumber)
+		} else {
+			accountMeta = fmt.Sprintf("%v|%v", accountAlias, accountNumber)
+		}
 		accountMetaSentence = fmt.Sprintf("%v (%v)", accountAlias, accountNumber)
 	}
 
@@ -63,7 +68,15 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 	}
 
 	// init shell
-	shell := exec.Command("bash", "-c", cmd)
+	var shell *exec.Cmd
+	if runtime.GOOS == "windows" {
+		// cmd = fmt.Sprintf(`cmd.exe /K "PROMPT [%s]$G"`, accountMeta)
+		// shell = exec.Command("cmd.exe", "/C", "start", cmd)
+		cmdPath := "C:\\Windows\\System32\\cmd.exe"
+		shell = exec.Command(cmdPath, "/K", fmt.Sprintf(`PROMPT [%s]$G`, accountMeta))
+	} else {
+		shell = exec.Command("bash", "-c", cmd)
+	}
 
 	// replicate current env vars and add stak
 	shell.Env = os.Environ()

--- a/lib/structs/configuraton-structs.go
+++ b/lib/structs/configuraton-structs.go
@@ -12,6 +12,7 @@ type Configuration struct {
 	Kion      Kion               `yaml:"kion"`
 	Favorites []Favorite         `yaml:"favorites"`
 	Profiles  map[string]Profile `yaml:"profiles"`
+	Browser   Browser            `yaml:"browser"`
 }
 
 // Kion holds information about the instance of Kion with which the application
@@ -41,4 +42,10 @@ type Favorite struct {
 type Profile struct {
 	Kion      Kion       `yaml:"kion"`
 	Favorites []Favorite `yaml:"favorites"`
+}
+
+// Browser holds configurations for browser options.
+type Browser struct {
+	FirefoxContainers bool   `yaml:"firefox_containers"`
+	CustomBrowserPath string `yaml:"custom_browser_path"`
 }

--- a/lib/structs/session-structs.go
+++ b/lib/structs/session-structs.go
@@ -1,0 +1,16 @@
+package structs
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Structs                                                                   //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// SessionInfo holds the information about the federated session.
+type SessionInfo struct {
+	AccountName    string
+	AccountNumber  string
+	AccountTypeID  uint
+	AwsIamRoleName string
+	Region         string
+}

--- a/main.go
+++ b/main.go
@@ -701,7 +701,14 @@ func favorites(cCtx *cli.Context) error {
 			return err
 		}
 		fmt.Printf("Federating into %s (%s) via %s\n", favorite.Name, favorite.Account, car.AwsIamRoleName)
-		return helper.OpenBrowserRedirect(url, car.AccountTypeID)
+		session := structs.SessionInfo{
+			AccountName:    favorite.Name,
+			AccountNumber:  car.AccountNumber,
+			AccountTypeID:  car.AccountTypeID,
+			AwsIamRoleName: car.AwsIamRoleName,
+			Region:         favorite.Region,
+		}
+		return helper.OpenBrowserRedirect(url, session, config.Browser)
 	} else {
 		// placeholder for our stak
 		var stak kion.STAK
@@ -780,7 +787,14 @@ func fedConsole(cCtx *cli.Context) error {
 		return err
 	}
 
-	return helper.OpenBrowserRedirect(url, car.AccountTypeID)
+	session := structs.SessionInfo{
+		AccountName:    car.AccountName,
+		AccountNumber:  car.AccountNumber,
+		AccountTypeID:  car.AccountTypeID,
+		AwsIamRoleName: car.AwsIamRoleName,
+		Region:         cCtx.String("region"),
+	}
+	return helper.OpenBrowserRedirect(url, session, config.Browser)
 }
 
 // listFavorites prints out the users stored favorites. Extra information is


### PR DESCRIPTION
Consolidating a few items that are being developed together.

- Firefox container support for Linux, Windows, and MacOS
- Windows sub-shell support for command prompt and power shell when authenticating into an account with the `stak` command