### PR TITLE
Add option to print saml auth url

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,15 +200,18 @@ __Global Options:__
                                        configured that uses username and password
                                        it is not required to specify its ID.
 
---saml_metadata_file FILENAME|URL      FILENAME or URL of the identity provider's
+--saml-metadata-file FILENAME|URL      FILENAME or URL of the identity provider's
                                        XML metadata document.  If a URL, this file
                                        will be downloaded every time the CLI app
                                        is run.  If a local file, this should be an
                                        absolute path to a file on your computer.
 
---saml_sp_issuer ISSUER                SAML Service Provider issuer value from Kion
+--saml-sp-issuer ISSUER                SAML Service Provider issuer value from Kion
                                        for example:
                                        https://mykioninstance.example/api/v1/saml/auth/1
+
+--saml-print-url                       Print the authentication URL instead of opening
+                                       it automatically with the default browser.
 
 --token TOKEN, -t TOKEN                Token (API or Bearer) used to authenticate.
 
@@ -376,6 +379,9 @@ KION_SAML_METADATA_FILE  FILENAME or URL of the identity provider's XML metadata
 KION_SAML_SP_ISSUER      The Kion IDMS issuer value, for example
                          https://mykioninstance.example/api/v1/saml/auth/1
 
+KION_SAML_PRINT_URL      "TRUE" to print the authentication url as opposed to
+                         automatically opening it in the default browser.
+                         Defaults to "FALSE".
 
 The following are maintained for compatibility with older Kion utilities:
 
@@ -398,7 +404,11 @@ kion.password                      Password for authentication, to be paired wit
 kion.idms_id                       IDMS ID, if using a custom IDMS in Kion.
 kion.saml_metadata_file            SAML metadata file location, URL or path.
 kion.saml_sp_issuer                Entity ID for the Kion SAML IDMS.
-kion.disable_cache                 Prevents Kion CLI from caching STAK if 'true', defaults 'false'.
+kion.saml_print_url                Set 'true' to print the authentication url as opposed to
+                                   automatically opening it in the default browser.
+                                   Defaults to 'false'.
+kion.disable_cache                 Prevents Kion CLI from caching STAK if 'true', defaults
+                                   to 'false'.
 
 FAVORITES
 ---------
@@ -407,7 +417,8 @@ favorites[N].account               Account number associated with the favorite.
 favorites[N].cloud_access_role     Cloud Access Role used to authenicate with the favorite.
 favorites[N].access_type           Favorite access type, 'web' or 'cli', defaults 'cli'.
 favorites[N].service               Service to open by default, for example 'rds', 'ec2', etc.
-                                   Applies only to 'web' access types, defaults to the dashboard.
+                                   Applies only to 'web' access types, defaults to the
+                                   main dashboard.
 
 PROFILES
 --------
@@ -416,8 +427,10 @@ profiles[NAME].FAVORITES           An instance of FAVORITES as defined above.
 
 BROWSER
 -------
-browser.firefox_container          Boolean to enable Firefox container support, defaults 'false'.
-                                   * Depends on the "Open external links in a container" plugin.
+browser.firefox_container          Boolean to enable Firefox container support, defaults
+                                   to 'false'.
+                                   ** Depends on the "Open external links in a container"
+                                   Firefox plugin.
 ```
 
 Note: if the authentication password is not provided as a Flag / Environment Variable / Configuration file entry, kion will prompt for the password on the command line. Kion will cache this password in the system keychain's encrypted storage. This may be preferable in environments where plaintext storage of credentials is frowned upon.

--- a/lib/kion/saml.go
+++ b/lib/kion/saml.go
@@ -134,8 +134,13 @@ func callExternalAuth(sp *saml2.SAMLServiceProvider, tokenChan chan SamlCallback
 
 	server := &http.Server{Addr: ":" + SAMLLocalAuthPort}
 
-	// create a timer for the 60-second timeout
-	timer := time.NewTimer(60 * time.Second)
+	// create a timer for the callback
+	var timer *time.Timer
+	if printUrl {
+		timer = time.NewTimer(180 * time.Second)
+	} else {
+		timer = time.NewTimer(60 * time.Second)
+	}
 
 	// goroutine to handle timeout and token receipt
 	go func() {

--- a/lib/kion/saml.go
+++ b/lib/kion/saml.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	saml2 "github.com/russellhaering/gosaml2"
 	samlTypes "github.com/russellhaering/gosaml2/types"
 	dsig "github.com/russellhaering/goxmldsig"
@@ -93,36 +94,42 @@ type SamlCallbackResult struct {
 	Err  error
 }
 
-func callExternalAuth(sp *saml2.SAMLServiceProvider, tokenChan chan SamlCallbackResult) (*AuthData, error) {
+func callExternalAuth(sp *saml2.SAMLServiceProvider, tokenChan chan SamlCallbackResult, printUrl bool) (*AuthData, error) {
 	authURL, err := sp.BuildAuthURL("")
 	if err != nil {
 		log.Fatalf("The login info is invalid.\n %v", err)
 	}
 
-	// define a context with 15 second timeout
-	var browserCommand *exec.Cmd
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
+	if printUrl {
+		// print the authentication URL for the user to copy
+		color.Cyan("Please copy the following URL into your browser to authenticate:")
+		fmt.Printf("\n%s\n\n", authURL)
+	} else {
+		// define a context with 15 second timeout
+		var browserCommand *exec.Cmd
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
 
-	// identify command based on operating system
-	switch runtime.GOOS {
-	case "windows":
-		browserCommand = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", authURL)
-	case "darwin":
-		browserCommand = exec.CommandContext(ctx, "open", authURL)
-	case "linux":
-		browserCommand = exec.CommandContext(ctx, "xdg-open", authURL)
-	default:
-		log.Println("Unsupported operating system:", runtime.GOOS)
-		return nil, fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
-	}
+		// identify command based on operating system
+		switch runtime.GOOS {
+		case "windows":
+			browserCommand = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", authURL)
+		case "darwin":
+			browserCommand = exec.CommandContext(ctx, "open", authURL)
+		case "linux":
+			browserCommand = exec.CommandContext(ctx, "xdg-open", authURL)
+		default:
+			log.Println("Unsupported operating system:", runtime.GOOS)
+			return nil, fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+		}
 
-	// run the command to open the browser
-	err = browserCommand.Run()
-	if ctx.Err() == context.DeadlineExceeded {
-		log.Println("Timeout reached while trying to open the browser.")
-	} else if err != nil {
-		log.Println("Error opening browser:", err)
+		// run the command to open the browser
+		err = browserCommand.Run()
+		if ctx.Err() == context.DeadlineExceeded {
+			log.Println("Timeout reached while trying to open the browser.")
+		} else if err != nil {
+			log.Println("Error opening browser:", err)
+		}
 	}
 
 	server := &http.Server{Addr: ":" + SAMLLocalAuthPort}
@@ -181,7 +188,7 @@ func callExternalAuth(sp *saml2.SAMLServiceProvider, tokenChan chan SamlCallback
 	return samlResult.Data, nil
 }
 
-func AuthenticateSAML(appUrl string, metadata *samlTypes.EntityDescriptor, serviceProviderIssuer string) (*AuthData, error) {
+func AuthenticateSAML(appUrl string, metadata *samlTypes.EntityDescriptor, serviceProviderIssuer string, printUrl bool) (*AuthData, error) {
 	certStore := dsig.MemoryX509CertificateStore{
 		Roots: []*x509.Certificate{},
 	}
@@ -322,11 +329,11 @@ func AuthenticateSAML(appUrl string, metadata *samlTypes.EntityDescriptor, servi
 		}, Err: nil}
 	})
 
-	return callExternalAuth(sp, tokenChan)
+	return callExternalAuth(sp, tokenChan, printUrl)
 }
 
 // AuthenticateSAMLOld is the old version of AuthenticateSAML that does not use a cookie-based exchange.
-func AuthenticateSAMLOld(appUrl string, metadata *samlTypes.EntityDescriptor, serviceProviderIssuer string) (*AuthData, error) {
+func AuthenticateSAMLOld(appUrl string, metadata *samlTypes.EntityDescriptor, serviceProviderIssuer string, printUrl bool) (*AuthData, error) {
 	certStore := dsig.MemoryX509CertificateStore{
 		Roots: []*x509.Certificate{},
 	}
@@ -436,7 +443,7 @@ func AuthenticateSAMLOld(appUrl string, metadata *samlTypes.EntityDescriptor, se
 		}, Err: nil}
 	})
 
-	return callExternalAuth(sp, tokenChan)
+	return callExternalAuth(sp, tokenChan, printUrl)
 }
 
 func DownloadSAMLMetadata(metadataUrl string) (*samlTypes.EntityDescriptor, error) {

--- a/lib/structs/configuraton-structs.go
+++ b/lib/structs/configuraton-structs.go
@@ -25,6 +25,7 @@ type Kion struct {
 	IDMS             string `yaml:"idms_id"`
 	SamlMetadataFile string `yaml:"saml_metadata_file"`
 	SamlIssuer       string `yaml:"saml_sp_issuer"`
+	SamlPrintUrl     bool   `yaml:"saml_print_url"`
 	DisableCache     bool   `yaml:"disable_cache"`
 }
 

--- a/main.go
+++ b/main.go
@@ -195,7 +195,9 @@ func AuthSAML(cCtx *cli.Context) error {
 		authData, err = kion.AuthenticateSAMLOld(
 			config.Kion.Url,
 			samlMetadata,
-			samlServiceProviderIssuer)
+			samlServiceProviderIssuer,
+			config.Kion.SamlPrintUrl,
+		)
 		if err != nil {
 			return err
 		}
@@ -203,7 +205,9 @@ func AuthSAML(cCtx *cli.Context) error {
 		authData, err = kion.AuthenticateSAML(
 			config.Kion.Url,
 			samlMetadata,
-			samlServiceProviderIssuer)
+			samlServiceProviderIssuer,
+			config.Kion.SamlPrintUrl,
+		)
 		if err != nil {
 			return err
 		}
@@ -1044,6 +1048,13 @@ func main() {
 				EnvVars:     []string{"KION_SAML_SP_ISSUER"},
 				Usage:       "SAML Service Provider `ISSUER`",
 				Destination: &config.Kion.SamlIssuer,
+			},
+			&cli.BoolFlag{
+				Name:        "saml-print-url",
+				Value:       config.Kion.SamlPrintUrl,
+				EnvVars:     []string{"KION_SAML_PRINT_URL"},
+				Usage:       "print SAML URL instead of opening browser",
+				Destination: &config.Kion.SamlPrintUrl,
 			},
 			&cli.StringFlag{
 				Name:        "token",


### PR DESCRIPTION
Fixes #71

Adds flag, env var, and config option to print SAML the authentication URL instead of automatically opening it in the users default browser.