### PR TITLE
Add support for specifying a Firefox Container Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,28 +397,31 @@ __Configuration File:__
 ```text
 KION
 ----
-kion.url                           URL to the target Kion instance.
-kion.api_key                       API key used to authenticate.
-kion.username                      Username for authentication, to be paried with password.
-kion.password                      Password for authentication, to be paired with username.
-kion.idms_id                       IDMS ID, if using a custom IDMS in Kion.
-kion.saml_metadata_file            SAML metadata file location, URL or path.
-kion.saml_sp_issuer                Entity ID for the Kion SAML IDMS.
-kion.saml_print_url                Set 'true' to print the authentication url as opposed to
-                                   automatically opening it in the default browser.
-                                   Defaults to 'false'.
-kion.disable_cache                 Prevents Kion CLI from caching STAK if 'true', defaults
-                                   to 'false'.
+kion.url                              URL to the target Kion instance.
+kion.api_key                          API key used to authenticate.
+kion.username                         Username for authentication, to be paried with password.
+kion.password                         Password for authentication, to be paired with username.
+kion.idms_id                          IDMS ID, if using a custom IDMS in Kion.
+kion.saml_metadata_file               SAML metadata file location, URL or path.
+kion.saml_sp_issuer                   Entity ID for the Kion SAML IDMS.
+kion.saml_print_url                   Set 'true' to print the authentication url as opposed to
+                                      automatically opening it in the default browser.
+                                      Defaults to 'false'.
+kion.disable_cache                    Prevents Kion CLI from caching STAK if 'true', defaults
+                                      to 'false'.
 
 FAVORITES
 ---------
-favorites[N].name                  Favorite name, used when calling `kion fav [name]`
-favorites[N].account               Account number associated with the favorite.
-favorites[N].cloud_access_role     Cloud Access Role used to authenicate with the favorite.
-favorites[N].access_type           Favorite access type, 'web' or 'cli', defaults 'cli'.
-favorites[N].service               Service to open by default, for example 'rds', 'ec2', etc.
-                                   Applies only to 'web' access types, defaults to the
-                                   main dashboard.
+favorites[N].name                     Favorite name, used when calling `kion fav [name]`
+favorites[N].account                  Account number associated with the favorite.
+favorites[N].cloud_access_role        Cloud Access Role used to authenicate with the favorite.
+favorites[N].access_type              Favorite access type, 'web' or 'cli', defaults 'cli'.
+favorites[N].service                  Service to open by default, for example 'rds', 'ec2', etc.
+                                      Applies only to 'web' access types, defaults to the
+                                      main dashboard.
+favorites[N].firefox_container_name   Firefox container name to use when opening the favorite.
+                                      Applies only to 'web' access types, defaults to the favorite name.
+                                      ** Only applies if the 'browser.firefox_container' option is set to 'true'.
 
 PROFILES
 --------

--- a/lib/commands/console.go
+++ b/lib/commands/console.go
@@ -61,5 +61,5 @@ func (c *Cmd) FedConsole(cCtx *cli.Context) error {
 		AwsIamRoleName: car.AwsIamRoleName,
 		Region:         cCtx.String("region"),
 	}
-	return helper.OpenBrowserRedirect(url, session, c.config.Browser, redirect)
+	return helper.OpenBrowserRedirect(url, session, c.config.Browser, redirect, "")
 }

--- a/lib/commands/favorite.go
+++ b/lib/commands/favorite.go
@@ -91,7 +91,7 @@ func (c *Cmd) Favorites(cCtx *cli.Context) error {
 			AwsIamRoleName: car.AwsIamRoleName,
 			Region:         favorite.Region,
 		}
-		return helper.OpenBrowserRedirect(url, session, c.config.Browser, favorite.Service)
+		return helper.OpenBrowserRedirect(url, session, c.config.Browser, favorite.Service, favorite.FirefoxContainerName)
 	} else {
 		// placeholder for our stak
 		var stak kion.STAK

--- a/lib/helper/browser.go
+++ b/lib/helper/browser.go
@@ -191,7 +191,7 @@ func OpenBrowser(url string, typeID uint) error {
 // OpenBrowserDirect opens up a URL in the users system default browser. It
 // uses the redirect_uri query parameter to handle the logout and redirect to
 // the federated login page.
-func OpenBrowserRedirect(target string, session structs.SessionInfo, config structs.Browser, redirect string) error {
+func OpenBrowserRedirect(target string, session structs.SessionInfo, config structs.Browser, redirect string, firefoxContainerName string) error {
 	var err error
 	var logoutURL string
 	var replacement string
@@ -236,10 +236,19 @@ func OpenBrowserRedirect(target string, session structs.SessionInfo, config stru
 	// generate the federation link
 	var federationLink string
 	if config.FirefoxContainers {
-		if runtime.GOOS == "windows" {
-			federationLink = fmt.Sprintf("ext+container:url=%s^&name=%s", encodedUrlOriginal, url.QueryEscape(session.AccountName))
+		var containerName string
+
+		// use the firefox container name if provided
+		if firefoxContainerName != "" {
+			containerName = firefoxContainerName
 		} else {
-			federationLink = fmt.Sprintf("ext+container:url=%s&name=%s", encodedUrlOriginal, url.QueryEscape(session.AccountName))
+			containerName = session.AccountName
+		}
+
+		if runtime.GOOS == "windows" {
+			federationLink = fmt.Sprintf("ext+container:url=%s^&name=%s", encodedUrlOriginal, url.QueryEscape(containerName))
+		} else {
+			federationLink = fmt.Sprintf("ext+container:url=%s&name=%s", encodedUrlOriginal, url.QueryEscape(containerName))
 		}
 	} else {
 		federationLink = fmt.Sprintf("%s%s", logoutURL, encodedUrlRedirect)

--- a/lib/structs/configuraton-structs.go
+++ b/lib/structs/configuraton-structs.go
@@ -32,12 +32,13 @@ type Kion struct {
 // Favorite holds information about user defined favorites used to quickly
 // access desired accounts.
 type Favorite struct {
-	Name       string `yaml:"name"`
-	Account    string `yaml:"account"`
-	CAR        string `yaml:"cloud_access_role"`
-	AccessType string `yaml:"access_type"`
-	Region     string `yaml:"region"`
-	Service    string `yaml:"service"`
+	Name                 string `yaml:"name"`
+	Account              string `yaml:"account"`
+	CAR                  string `yaml:"cloud_access_role"`
+	AccessType           string `yaml:"access_type"`
+	Region               string `yaml:"region"`
+	Service              string `yaml:"service"`
+	FirefoxContainerName string `yaml:"firefox_container_name"`
 }
 
 // Profile holds an alternate configuration for Kion and Favorites.


### PR DESCRIPTION
- Adds a `firefox_configuration_name` to the favorite configuration that allows you to override the name of the Firefox Container.
- Updates the `README.md` and `CHANGELOG.md`

This is helpful when you want a favorite with a shorthand name, making it easy to type in the terminal, but like the container to have a full name. Additionally, if you're going to have multiple favorites share a Firefox Container, this allows for that.