### PR TITLE
Compile with config

### DIFF
--- a/doc/config_sop.md
+++ b/doc/config_sop.md
@@ -1,0 +1,20 @@
+Config SOP
+==========
+
+When adding new configuration options there are a few things to keep in mind in
+order to support several config features and established operational behavior.
+This SOP ensures the appropriate precedence is followed and users can
+intuitively use new options in ways they have established with existing ones.
+This SOP assumes you are adding an option to the configuration file that will
+also be a global flag / option.
+
+1. Add the option to the configuration struct `lib/structs/configuraton-structs.go`
+2. Add the option to the defaults override file `lib/defaults/defaults.yml` only if it is non-sensitive in nature
+3. Set the option as a flag in `main.go`, this is what handles precedence as documented in the repo `README.md` file
+4. if a non string var add a manual re-setting of it for when profiles are switched
+5. Test to ensure precedence is being followed as expected:
+  1. No `defaults.yml` entry, no config file
+  2. Then add an override in `defaults.yml`
+  3. Then add an override entry in your `~/.kion.yml`
+  4. Then add an override in the environment variable
+  5. Then add an override in the flag option

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1,0 +1,13 @@
+package defaults
+
+import (
+	"embed"
+)
+
+//go:embed defaults.yml
+var ConfigFS embed.FS
+
+// GetDefaultConfig returns the default configuration.
+func GetDefaultConfig() ([]byte, error) {
+	return ConfigFS.ReadFile("defaults.yml")
+}

--- a/lib/defaults/defaults.yml
+++ b/lib/defaults/defaults.yml
@@ -1,0 +1,34 @@
+################################################################################
+##                                                                            ##
+##  Attention!!                                                               ##
+##                                                                            ##
+##  vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv  ##
+##                                                                            ##
+##  DO NOT STORE SENSITIVE CONFIGURATIONS IN THIS FILE. All contents will be  ##
+##  stored as plain text inside the compiled Kion CLI binary & be accessible  ##
+##  to any user with read access.                                             ##
+##                                                                            ##
+##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ##
+##                                                                            ##
+##  Values stored here are overrides to the Kion CLI defaults (the config     ##
+##  structs null values). This is provided as a convenience to create custom  ##
+##  builds of the CLI for distribution within companies. Precedence will be   ##
+##  as follows:                                                               ##
+##                                                                            ##
+##  Flag > Environment Variables > Config File > Default Values               ##
+##                                               `------------'               ##
+##                                                     |                      ##
+##         .-------------------------------------------'                      ##
+##         V                                                                  ##
+##  Default Values (THIS DEFAULTS.YML > config struct null values)            ##
+##                                                                            ##
+################################################################################
+
+kion:
+  url: "https://portal.kion.io"
+  idms_id: ""
+  saml_metadata_file: ""
+  saml_sp_issuer: ""
+  saml_print_url: false
+  disable_cache: false
+  debug_mode: false

--- a/lib/helper/configuration.go
+++ b/lib/helper/configuration.go
@@ -1,8 +1,11 @@
 package helper
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
+	"github.com/kionsoftware/kion-cli/lib/defaults"
 	"github.com/kionsoftware/kion-cli/lib/structs"
 
 	"gopkg.in/yaml.v2"
@@ -14,16 +17,36 @@ import (
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-// LoadConfig reads in the configuration yaml file located at `configFile`.
+// LoadConfig reads in the embedded configuration file as well as the users
+// configuration yaml file located at `configFile`. Precedence is given to the
+// users configuration file, so any values set there will override the embedded
+// defaults.
 func LoadConfig(filename string, config *structs.Configuration) error {
-	// read in the file
-	bytes, err := os.ReadFile(filename)
+	// read embedded defaults into the config
+	defaultConfig, err := defaults.GetDefaultConfig()
+	if err == nil {
+		// only try to parse if we successfully got the embedded config
+		if err := yaml.Unmarshal(defaultConfig, &config); err != nil {
+			return fmt.Errorf("failed to parse embedded configuration: %w", err)
+		}
+	}
+
+	// try to read users config file
+	data, err := os.ReadFile(filename)
 	if err != nil {
+		// if file doesn't exist, just use embedded defaults
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		return err
 	}
 
-	// unmarshal to config struct
-	return yaml.Unmarshal(bytes, &config)
+	// parse external config and override defaults
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return fmt.Errorf("failed to parse config file %s: %w", filename, err)
+	}
+
+	return nil
 }
 
 // SaveConfig saves the entirety of the current config to the users config file.

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -55,7 +54,7 @@ func main() {
 
 	// load configuration file
 	err = helper.LoadConfig(configPath, &config)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err != nil {
 		color.Red(" Error: %v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Adds the ability for users to create custom builds of the Kion CLI with custom configurations baked in. Users would edit the `lib/defaults/defaults.yml` file as desired the run `make build` to create the custom `kion` binary.