### PR TITLE
Add favorite helper text and quiet flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Version 0.12.0 adds the ability to create custom builds of the Kion CLI with cus
 ### Added
 
 - Ability to create custom Kion CLI binaries with user defined defaults [kionsoftware/kion-cli/pull/96]
-- Helper output showing users how to store recently accessed accounts a favorite [kionsoftware/kion-cli/pull/97]
+- Helper output showing users how to store recently accessed accounts as a favorite [kionsoftware/kion-cli/pull/97]
 
 [0.11.0] - 2025-06-12
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,12 @@ Notes for upgrading...
 [0.12.0] - 2025.06.13
 ---------------------
 
-Version 0.12.0 adds the ability to create custom builds of the Kion CLI with customer specific configurations. This allows for easier team on boarding to the utility. See the __Custom Builds__ section in the repository `README.md` for details on usage.
+Version 0.12.0 adds the ability to create custom builds of the Kion CLI with customer specific configurations. This allows for easier team on boarding to the utility. See the __Custom Builds__ section in the repository `README.md` for details on usage. Additionally version 0.12.0 adds new output to the `stak` and `console` commands guiding users on how to create favorites for future use. The new output will be the default behavior but can be disabled with the new `quiet` option, configurable via the config file, `KION_QUIET` environment variable, or global option flag.
 
 ### Added
 
 - Ability to create custom Kion CLI binaries with user defined defaults [kionsoftware/kion-cli/pull/96]
+- Helper output showing users how to store recently accessed accounts a favorite [kionsoftware/kion-cli/pull/97]
 
 [0.11.0] - 2025-06-12
 ---------------------

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ __Global Options:__
 
 --debug                                Enables debug output for certain functions.
 
+--quiet                                Reduces output for certain functions.
+
 --profile PROFILE                      Use the specified PROFILE from the Kion CLI
                                        configuration file. If no profile is specified
                                        the default will be used.
@@ -384,6 +386,10 @@ KION_SAML_SP_ISSUER      The Kion IDMS issuer value, for example
 KION_SAML_PRINT_URL      "TRUE" to print the authentication url as opposed to
                          automatically opening it in the default browser.
                          Defaults to "FALSE".
+
+KION_DEBUG               "TRUE" to enable verbose debugging of the Kion CLI.
+
+KION_QUIET               "TRUE" to reduce messages for quieter operation.
 
 The following are maintained for compatibility with older Kion utilities:
 

--- a/doc/config_sop.md
+++ b/doc/config_sop.md
@@ -11,7 +11,7 @@ also be a global flag / option.
 1. Add the option to the configuration struct `lib/structs/configuraton-structs.go`
 2. Add the option to the defaults override file `lib/defaults/defaults.yml` only if it is non-sensitive in nature
 3. Set the option as a flag in `main.go`, this is what handles precedence as documented in the repo `README.md` file
-4. if a non string var add a manual re-setting of it for when profiles are switched
+4. If a non string var add a manual re-setting of it for when profiles are switched in `lib/commands/commands.go`
 5. Test to ensure precedence is being followed as expected:
   1. No `defaults.yml` entry, no config file
   2. Then add an override in `defaults.yml`

--- a/doc/man1/kion.1
+++ b/doc/man1/kion.1
@@ -42,6 +42,8 @@ Token (API or Bearer) used to authenticate.
 Disable the use of cache for Kion CLI.
 .It --debug
 Enable debug mode for additional CLI output.
+.It --quiet
+Enable quiet mode for to reduce unnecessary output.
 .It --profile PROFILE
 Use the specified PROFILE from the Kion CLI configuration file.
 .It --help, -h
@@ -152,6 +154,10 @@ FILENAME or URL of the identity provider's XML metadata document.
 The Kion IDMS issuer value.
 .It KION_SAML_PRINT_URL
 "TRUE" to print the authentication url as opposed to automatically opening it in the default browser. Defaults to "FALSE".
+.It KION_DEBUG
+"TRUE" to enable verbose debugging of the Kion CLI.
+.It KION_QUIET
+"TRUE" to reduce messages for quieter operation.
 .El
 
 .Sh FILES

--- a/lib/commands/commands.go
+++ b/lib/commands/commands.go
@@ -179,8 +179,11 @@ func (c *Cmd) handleProfile(profileName string, cCtx *cli.Context) error {
 		// profiles values
 		// bool values need to be explicitly handled here since we're not iterating
 		setStrings := make(map[string]string)
+
 		var disableCacheFlagged bool
 		var debugFlagged bool
+		var quietFlagged bool
+
 		setGlobalFlags := cCtx.FlagNames()
 		for _, flag := range setGlobalFlags {
 			switch flag {
@@ -203,6 +206,8 @@ func (c *Cmd) handleProfile(profileName string, cCtx *cli.Context) error {
 				disableCacheFlagged = true
 			case "debug":
 				debugFlagged = true
+			case "quiet":
+				quietFlagged = true
 			}
 		}
 
@@ -229,6 +234,9 @@ func (c *Cmd) handleProfile(profileName string, cCtx *cli.Context) error {
 		}
 		if debugFlagged {
 			c.config.Kion.DebugMode = true
+		}
+		if quietFlagged {
+			c.config.Kion.QuietMode = true
 		}
 	}
 	return nil

--- a/lib/commands/console.go
+++ b/lib/commands/console.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/kionsoftware/kion-cli/lib/helper"
 	"github.com/kionsoftware/kion-cli/lib/kion"
@@ -53,6 +54,13 @@ func (c *Cmd) FedConsole(cCtx *cli.Context) error {
 
 	// grab the second argument, used as a redirect parameter
 	redirect := getSecondArgument(cCtx)
+
+	// print out how to store as a favorite
+	if !c.config.Kion.QuietMode {
+		if err := helper.PrintFavoriteConfig(os.Stdout, car, cCtx.String("region"), "web"); err != nil {
+			return err
+		}
+	}
 
 	session := structs.SessionInfo{
 		AccountName:    car.AccountName,

--- a/lib/commands/stak.go
+++ b/lib/commands/stak.go
@@ -107,6 +107,11 @@ func (c *Cmd) GenStaks(cCtx *cli.Context) error {
 	case "save":
 		return helper.SaveAWSCreds(stak, car)
 	case "subshell":
+		if !c.config.Kion.QuietMode {
+			if err := helper.PrintFavoriteConfig(os.Stdout, car, region, "cli"); err != nil {
+				return err
+			}
+		}
 		var displayAlais string
 		if accAlias != "" {
 			displayAlais = accAlias

--- a/lib/defaults/defaults.yml
+++ b/lib/defaults/defaults.yml
@@ -32,3 +32,4 @@ kion:
   saml_print_url: false
   disable_cache: false
   debug_mode: false
+  quiet_mode: false

--- a/lib/helper/output.go
+++ b/lib/helper/output.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/kionsoftware/kion-cli/lib/kion"
 )
 
@@ -34,11 +35,26 @@ func PrintSTAK(w io.Writer, stak kion.STAK, region string) error {
 
 	// conditionally print region
 	if region != "" {
-		fmt.Fprintf(w, "export AWS_REGION=%v\n", region)
+		fmt.Fprintf(w, "%v AWS_REGION=%v\n", export, region)
 	}
 
 	// print the stak
 	fmt.Fprintf(w, "%v AWS_ACCESS_KEY_ID=%v\nexport AWS_SECRET_ACCESS_KEY=%v\nexport AWS_SESSION_TOKEN=%v\n", export, stak.AccessKey, stak.SecretAccessKey, stak.SessionToken)
+
+	return nil
+}
+
+// PrintFavoriteConfig prints out how to save the current selection as a
+// favorite within the users configuration file.
+func PrintFavoriteConfig(w io.Writer, car kion.CAR, region string, access_type string) error {
+	color.New(color.FgBlue).Fprintf(w, "\nTo save your selection as a favorite add the following to\nyour configuration file under the 'favorites:' section:\n")
+	fmt.Fprintf(w, "  - name: ")
+	color.New(color.FgGreen).Fprintf(w, "[your favorite alias]\n")
+	fmt.Fprintf(w, "    account: %v\n    cloud_access_role: %v\n", car.AccountNumber, car.Name)
+	if region != "" {
+		fmt.Fprintf(w, "    region: %v\n", region)
+	}
+	fmt.Fprintf(w, "    access_type: %v\n\n", access_type)
 
 	return nil
 }

--- a/lib/structs/configuraton-structs.go
+++ b/lib/structs/configuraton-structs.go
@@ -28,6 +28,7 @@ type Kion struct {
 	SamlPrintUrl     bool   `yaml:"saml_print_url"`
 	DisableCache     bool   `yaml:"disable_cache"`
 	DebugMode        bool   `yaml:"debug_mode"`
+	QuietMode        bool   `yaml:"quiet_mode"`
 }
 
 // Favorite holds information about user defined favorites used to quickly

--- a/main.go
+++ b/main.go
@@ -187,6 +187,13 @@ func main() {
 				Usage:       "enable debug mode for verbose logging",
 				Destination: &config.Kion.DebugMode,
 			},
+			&cli.BoolFlag{
+				Name:        "quiet",
+				Value:       config.Kion.QuietMode,
+				EnvVars:     []string{"KION_QUIET"},
+				Usage:       "enable quiet mode to reduce output",
+				Destination: &config.Kion.QuietMode,
+			},
 		},
 
 		////////////////


### PR DESCRIPTION
This PR adds additional output to the `console` and `stak` commands to show users how to store their selection as a favorite. There is also a new quiet configuration option that will prevent these messages which are on by defualt.

Addresses the discussion: https://github.com/kionsoftware/kion-cli/discussions/91