### PR TITLE
Bump version of go from 1.22 to 1.24.4

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.1'
+          go-version: '1.24.4'
 
       - name: Run Tests
         uses: n8maninger/action-golang-test@v1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.1'
+          go-version: '1.24.4'
           cache: false
 
       - name: Run Linter
@@ -31,7 +31,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.55.2
+          version: v2.1.6
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
           cache: false
 
       - name: Run Linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,70 +1,86 @@
+version: "2"
 run:
-  timeout: 5m
   issues-exit-code: 1
   tests: true
-output:
-  print-issued-lines: true
-  print-linter-name: true
-linters-settings:
-  dupl:
-    threshold: 150
-  errcheck:
-    check-type-assertions: false
-    check-blank: false
-  goconst:
-    min-len: 3
-    min-occurrences: 10
-  gocyclo:
-    min-complexity: 30
-  gofmt:
-    simplify: true
-  goimports:
-    local-prefixes: github.com/kionsoftware/kion-cli
-  govet:
-    enable:
-      - shadow
-  lll:
-    line-length: 120
-    tab-width: 1
-  misspell:
-    locale: US
-    ignore-words:
-      - cancelled
-  sloglint:
-    attr-only: true
-  unparam:
-    check-exported: false
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
-    # - dupl
-    - errcheck
     - bodyclose
+    - errcheck
     - goconst
     - gocyclo
-    - gofmt
-    # - goimports
-    - gosimple
     - govet
     - ineffassign
-    # - lll
     - misspell
     - sloglint
     - staticcheck
     - unconvert
     - unparam
     - unused
+  settings:
+    dupl:
+      threshold: 150
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+    goconst:
+      min-len: 3
+      min-occurrences: 10
+    gocyclo:
+      min-complexity: 30
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 120
+      tab-width: 1
+    misspell:
+      locale: US
+      ignore-rules:
+        - cancelled
+    sloglint:
+      attr-only: true
+    unparam:
+      check-exported: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: (.+)\.go$
+        text: 'shadow: declaration of .err. shadows declaration'
+      - path: (.+)\.go$
+        text: 'shadow: declaration of &#34;err&#34; shadows declaration'
+    paths:
+      - tools/*
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude:
-    - "shadow: declaration of .err. shadows declaration"
-    - "shadow: declaration of &#34;err&#34; shadows declaration"
   max-same-issues: 0
-  exclude-dirs:
-    - tools/*
 severity:
-  default-severity: error
+  default: error
   rules:
     - linters:
         - gofmt
       severity: info
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/kionsoftware/kion-cli
+  exclusions:
+    generated: lax
+    paths:
+      - tools/*
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/kionsoftware/kion-cli
 
-go 1.22
+go 1.24.4
 
 require (
+	github.com/99designs/keyring v1.2.2
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/fatih/color v1.15.0
 	github.com/hashicorp/go-version v1.6.0
@@ -14,7 +15,6 @@ require (
 
 require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
-	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
-github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
@@ -74,7 +72,8 @@ github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWy
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Upgrading go and golang-ci-lint to latest versions.