### PR TITLE
Add other binaries from Makefile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ Thumbs.db
 #######################
 
 /kion
+/kion-darwin-arm
+/kion-darwin
+/kion-linux-arm
+/kion-linux
+/kion-arm.exe
+/kion.exe
 profile.cov
 tools/golangci-lint
 


### PR DESCRIPTION
Adds the other binaries listed in the platform-specific commands from the Makefile to `.gitignore`.

After building the `kion.exe` on Windows, we had an untracked file and wanted to fix it.