### PR TITLE
Add tests and fix ValidateCmdRun bug

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1,0 +1,248 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/kionsoftware/kion-cli/lib/kion"
+)
+
+func TestNewNullCache(t *testing.T) {
+	cache := NewNullCache()
+	if cache == nil {
+		t.Error("NewNullCache() returned nil")
+	}
+}
+
+func TestNullCacheImplementsInterface(t *testing.T) {
+	// Verify NullCache satisfies the Cache interface at compile time.
+	// This is a compile-time check - if NullCache doesn't implement Cache,
+	// this file won't compile.
+	var _ Cache = (*NullCache)(nil)
+}
+
+func TestNullCache_Stak(t *testing.T) {
+	tests := []struct {
+		name     string
+		carName  string
+		accNum   string
+		accAlias string
+		stak     kion.STAK
+	}{
+		{
+			name:     "typical values",
+			carName:  "AdminRole",
+			accNum:   "123456789012",
+			accAlias: "my-account",
+			stak: kion.STAK{
+				AccessKey:       "AKIAIOSFODNN7EXAMPLE",
+				SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				SessionToken:    "token123",
+			},
+		},
+		{
+			name:     "empty strings",
+			carName:  "",
+			accNum:   "",
+			accAlias: "",
+			stak:     kion.STAK{},
+		},
+		{
+			name:     "only car name",
+			carName:  "ReadOnly",
+			accNum:   "",
+			accAlias: "",
+			stak:     kion.STAK{AccessKey: "AKIA123"},
+		},
+		{
+			name:     "special characters",
+			carName:  "role/with/slashes",
+			accNum:   "000000000000",
+			accAlias: "alias-with-dashes_and_underscores",
+			stak:     kion.STAK{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cache := NewNullCache()
+
+			// SetStak should always succeed
+			err := cache.SetStak(test.carName, test.accNum, test.accAlias, test.stak)
+			if err != nil {
+				t.Errorf("SetStak() returned error: %v", err)
+			}
+
+			// GetStak should always return empty, false, nil
+			stak, found, err := cache.GetStak(test.carName, test.accNum, test.accAlias)
+			if err != nil {
+				t.Errorf("GetStak() returned error: %v", err)
+			}
+			if found {
+				t.Error("GetStak() returned found=true, want false")
+			}
+			if stak != (kion.STAK{}) {
+				t.Errorf("GetStak() returned non-empty STAK: %+v", stak)
+			}
+		})
+	}
+}
+
+func TestNullCache_Session(t *testing.T) {
+	tests := []struct {
+		name    string
+		session kion.Session
+	}{
+		{
+			name: "typical session",
+			session: kion.Session{
+				IDMSID:   1,
+				UserName: "user@example.com",
+			},
+		},
+		{
+			name:    "empty session",
+			session: kion.Session{},
+		},
+		{
+			name: "zero IDMS ID",
+			session: kion.Session{
+				IDMSID:   0,
+				UserName: "user@example.com",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cache := NewNullCache()
+
+			// SetSession should always succeed
+			err := cache.SetSession(test.session)
+			if err != nil {
+				t.Errorf("SetSession() returned error: %v", err)
+			}
+
+			// GetSession should always return empty, false, nil
+			session, found, err := cache.GetSession()
+			if err != nil {
+				t.Errorf("GetSession() returned error: %v", err)
+			}
+			if found {
+				t.Error("GetSession() returned found=true, want false")
+			}
+			if session != (kion.Session{}) {
+				t.Errorf("GetSession() returned non-empty Session: %+v", session)
+			}
+		})
+	}
+}
+
+func TestNullCache_Password(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		idmsID   uint
+		username string
+		password string
+	}{
+		{
+			name:     "typical values",
+			host:     "https://kion.example.com",
+			idmsID:   1,
+			username: "user@example.com",
+			password: "secretpassword123",
+		},
+		{
+			name:     "empty strings",
+			host:     "",
+			idmsID:   0,
+			username: "",
+			password: "",
+		},
+		{
+			name:     "zero IDMS ID",
+			host:     "https://kion.example.com",
+			idmsID:   0,
+			username: "user@example.com",
+			password: "password",
+		},
+		{
+			name:     "special characters in password",
+			host:     "https://kion.example.com",
+			idmsID:   1,
+			username: "user@example.com",
+			password: "p@$$w0rd!#$%^&*()",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cache := NewNullCache()
+
+			// SetPassword should always succeed
+			err := cache.SetPassword(test.host, test.idmsID, test.username, test.password)
+			if err != nil {
+				t.Errorf("SetPassword() returned error: %v", err)
+			}
+
+			// GetPassword should always return empty, false, nil
+			password, found, err := cache.GetPassword(test.host, test.idmsID, test.username)
+			if err != nil {
+				t.Errorf("GetPassword() returned error: %v", err)
+			}
+			if found {
+				t.Error("GetPassword() returned found=true, want false")
+			}
+			if password != "" {
+				t.Errorf("GetPassword() returned non-empty password: %q", password)
+			}
+		})
+	}
+}
+
+func TestNullCache_FlushCache(t *testing.T) {
+	cache := NewNullCache()
+	err := cache.FlushCache()
+	if err != nil {
+		t.Errorf("FlushCache() returned error: %v", err)
+	}
+
+	// Calling multiple times should still succeed
+	err = cache.FlushCache()
+	if err != nil {
+		t.Errorf("FlushCache() second call returned error: %v", err)
+	}
+}
+
+func TestNullCache_MultipleInstances(t *testing.T) {
+	// Verify that multiple NullCache instances don't interfere with each other
+	// (they shouldn't, since they don't store anything)
+	cache1 := NewNullCache()
+	cache2 := NewNullCache()
+
+	// Set data on cache1
+	_ = cache1.SetStak("role1", "111111111111", "alias1", kion.STAK{AccessKey: "KEY1"})
+	_ = cache1.SetSession(kion.Session{IDMSID: 1, UserName: "user1"})
+	_ = cache1.SetPassword("host1", 1, "user1", "pass1")
+
+	// Set different data on cache2
+	_ = cache2.SetStak("role2", "222222222222", "alias2", kion.STAK{AccessKey: "KEY2"})
+	_ = cache2.SetSession(kion.Session{IDMSID: 2, UserName: "user2"})
+	_ = cache2.SetPassword("host2", 2, "user2", "pass2")
+
+	// Both should return empty for any query
+	stak1, found1, _ := cache1.GetStak("role1", "111111111111", "alias1")
+	stak2, found2, _ := cache2.GetStak("role2", "222222222222", "alias2")
+
+	if found1 || found2 {
+		t.Error("NullCache should never return found=true")
+	}
+	if stak1 != (kion.STAK{}) || stak2 != (kion.STAK{}) {
+		t.Error("NullCache should always return empty STAK")
+	}
+}
+
+func TestRealCacheImplementsInterface(t *testing.T) {
+	// Verify RealCache satisfies the Cache interface at compile time.
+	var _ Cache = (*RealCache)(nil)
+}

--- a/lib/commands/validators_test.go
+++ b/lib/commands/validators_test.go
@@ -1,0 +1,435 @@
+package commands
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/kionsoftware/kion-cli/lib/structs"
+	"github.com/urfave/cli/v2"
+)
+
+// newTestContext creates a cli.Context for testing with the given flags.
+func newTestContext(t *testing.T, flags map[string]string) *cli.Context {
+	t.Helper()
+	app := &cli.App{}
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	// Register all flags we might need
+	for name := range flags {
+		set.String(name, "", "")
+	}
+
+	// Set flag values
+	for name, value := range flags {
+		if err := set.Set(name, value); err != nil {
+			t.Fatalf("failed to set flag %q to %q: %v", name, value, err)
+		}
+	}
+
+	return cli.NewContext(app, set, nil)
+}
+
+func TestValidateCmdStak(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "no flags - valid",
+			flags:   map[string]string{},
+			wantErr: false,
+		},
+		{
+			name: "account and car - valid",
+			flags: map[string]string{
+				"account": "123456789012",
+				"car":     "AdminRole",
+			},
+			wantErr: false,
+		},
+		{
+			name: "alias and car - valid",
+			flags: map[string]string{
+				"alias": "my-account",
+				"car":   "AdminRole",
+			},
+			wantErr: false,
+		},
+		{
+			name: "account without car - invalid",
+			flags: map[string]string{
+				"account": "123456789012",
+			},
+			wantErr: true,
+			errMsg:  "must specify --car parameter when using --account or --alias",
+		},
+		{
+			name: "alias without car - invalid",
+			flags: map[string]string{
+				"alias": "my-account",
+			},
+			wantErr: true,
+			errMsg:  "must specify --car parameter when using --account or --alias",
+		},
+		{
+			name: "car without account or alias - invalid",
+			flags: map[string]string{
+				"car": "AdminRole",
+			},
+			wantErr: true,
+			errMsg:  "must specify --account OR --alias parameter when using --car",
+		},
+		{
+			name: "all three flags - valid",
+			flags: map[string]string{
+				"account": "123456789012",
+				"alias":   "my-account",
+				"car":     "AdminRole",
+			},
+			wantErr: false,
+		},
+	}
+
+	cmd := &Cmd{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := newTestContext(t, test.flags)
+			err := cmd.ValidateCmdStak(ctx)
+
+			if test.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if err.Error() != test.errMsg {
+					t.Errorf("error = %q, want %q", err.Error(), test.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCmdConsole(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "no flags - valid",
+			flags:   map[string]string{},
+			wantErr: false,
+		},
+		{
+			name: "account and car - valid",
+			flags: map[string]string{
+				"account": "123456789012",
+				"car":     "AdminRole",
+			},
+			wantErr: false,
+		},
+		{
+			name: "alias and car - valid",
+			flags: map[string]string{
+				"alias": "my-account",
+				"car":   "AdminRole",
+			},
+			wantErr: false,
+		},
+		{
+			name: "car without account or alias - invalid",
+			flags: map[string]string{
+				"car": "AdminRole",
+			},
+			wantErr: true,
+			errMsg:  "must specify --account or --alias parameter when using --car",
+		},
+		{
+			name: "account without car - invalid",
+			flags: map[string]string{
+				"account": "123456789012",
+			},
+			wantErr: true,
+			errMsg:  "must specify --car parameter when using --account or --alias",
+		},
+		{
+			name: "alias without car - invalid",
+			flags: map[string]string{
+				"alias": "my-account",
+			},
+			wantErr: true,
+			errMsg:  "must specify --car parameter when using --account or --alias",
+		},
+	}
+
+	cmd := &Cmd{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := newTestContext(t, test.flags)
+			err := cmd.ValidateCmdConsole(ctx)
+
+			if test.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if err.Error() != test.errMsg {
+					t.Errorf("error = %q, want %q", err.Error(), test.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCmdRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		flags     map[string]string
+		favorites []structs.Favorite
+		wantErr   bool
+		errMsg    string
+	}{
+		// Favorite-based tests
+		{
+			name: "valid favorite",
+			flags: map[string]string{
+				"favorite": "my-fav",
+			},
+			favorites: []structs.Favorite{
+				{Name: "my-fav", Account: "123456789012", CAR: "AdminRole"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "favorite not found",
+			flags: map[string]string{
+				"favorite": "nonexistent",
+			},
+			favorites: []structs.Favorite{
+				{Name: "my-fav", Account: "123456789012", CAR: "AdminRole"},
+			},
+			wantErr: true,
+			errMsg:  "can't find favorite",
+		},
+		{
+			name: "favorite not found - empty favorites list",
+			flags: map[string]string{
+				"favorite": "my-fav",
+			},
+			favorites: []structs.Favorite{},
+			wantErr:   true,
+			errMsg:    "can't find favorite",
+		},
+
+		// Account/alias + car tests (without favorite)
+		{
+			name: "account and car without favorite - valid",
+			flags: map[string]string{
+				"account": "123456789012",
+				"car":     "AdminRole",
+			},
+			favorites: []structs.Favorite{},
+			wantErr:   false,
+		},
+		{
+			name: "alias and car without favorite - valid",
+			flags: map[string]string{
+				"alias": "my-account",
+				"car":   "AdminRole",
+			},
+			favorites: []structs.Favorite{},
+			wantErr:   false,
+		},
+		{
+			name: "account, alias and car without favorite - valid",
+			flags: map[string]string{
+				"account": "123456789012",
+				"alias":   "my-account",
+				"car":     "AdminRole",
+			},
+			favorites: []structs.Favorite{},
+			wantErr:   false,
+		},
+
+		// Invalid combinations
+		{
+			name:      "no flags at all - invalid",
+			flags:     map[string]string{},
+			favorites: []structs.Favorite{},
+			wantErr:   true,
+			errMsg:    "must specify either --fav OR --account and --car  OR --alias and --car parameters",
+		},
+		{
+			name: "account without car - invalid",
+			flags: map[string]string{
+				"account": "123456789012",
+			},
+			favorites: []structs.Favorite{},
+			wantErr:   true,
+			errMsg:    "must specify either --fav OR --account and --car  OR --alias and --car parameters",
+		},
+		{
+			name: "alias without car - invalid",
+			flags: map[string]string{
+				"alias": "my-account",
+			},
+			favorites: []structs.Favorite{},
+			wantErr:   true,
+			errMsg:    "must specify either --fav OR --account and --car  OR --alias and --car parameters",
+		},
+		{
+			name: "car without account or alias - invalid",
+			flags: map[string]string{
+				"car": "AdminRole",
+			},
+			favorites: []structs.Favorite{},
+			wantErr:   true,
+			errMsg:    "must specify either --fav OR --account and --car  OR --alias and --car parameters",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &Cmd{
+				config: &structs.Configuration{
+					Favorites: test.favorites,
+				},
+			}
+			ctx := newTestContext(t, test.flags)
+			err := cmd.ValidateCmdRun(ctx)
+
+			if test.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if err.Error() != test.errMsg {
+					t.Errorf("error = %q, want %q", err.Error(), test.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCmdRun_SetsDefaultRegion(t *testing.T) {
+	t.Run("sets region from favorite", func(t *testing.T) {
+		cmd := &Cmd{
+			config: &structs.Configuration{
+				Favorites: []structs.Favorite{
+					{Name: "my-fav", Account: "123456789012", CAR: "AdminRole", Region: "us-west-2"},
+				},
+				Kion: structs.Kion{
+					DefaultRegion: "",
+				},
+			},
+		}
+
+		ctx := newTestContext(t, map[string]string{"favorite": "my-fav"})
+		err := cmd.ValidateCmdRun(ctx)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cmd.config.Kion.DefaultRegion != "us-west-2" {
+			t.Errorf("DefaultRegion = %q, want %q", cmd.config.Kion.DefaultRegion, "us-west-2")
+		}
+	})
+
+	t.Run("does not change region when favorite has no region", func(t *testing.T) {
+		cmd := &Cmd{
+			config: &structs.Configuration{
+				Favorites: []structs.Favorite{
+					{Name: "my-fav", Account: "123456789012", CAR: "AdminRole", Region: ""},
+				},
+				Kion: structs.Kion{
+					DefaultRegion: "us-east-1",
+				},
+			},
+		}
+
+		ctx := newTestContext(t, map[string]string{"favorite": "my-fav"})
+		err := cmd.ValidateCmdRun(ctx)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cmd.config.Kion.DefaultRegion != "us-east-1" {
+			t.Errorf("DefaultRegion = %q, want %q (should be unchanged)", cmd.config.Kion.DefaultRegion, "us-east-1")
+		}
+	})
+
+	t.Run("does not set region when using account+car", func(t *testing.T) {
+		cmd := &Cmd{
+			config: &structs.Configuration{
+				Favorites: []structs.Favorite{},
+				Kion: structs.Kion{
+					DefaultRegion: "us-east-1",
+				},
+			},
+		}
+
+		ctx := newTestContext(t, map[string]string{
+			"account": "123456789012",
+			"car":     "AdminRole",
+		})
+		err := cmd.ValidateCmdRun(ctx)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cmd.config.Kion.DefaultRegion != "us-east-1" {
+			t.Errorf("DefaultRegion = %q, want %q (should be unchanged)", cmd.config.Kion.DefaultRegion, "us-east-1")
+		}
+	})
+}
+
+func TestValidateCmdRun_NilFavorites(t *testing.T) {
+	t.Run("nil favorites with account+car succeeds", func(t *testing.T) {
+		cmd := &Cmd{
+			config: &structs.Configuration{
+				Favorites: nil,
+			},
+		}
+
+		ctx := newTestContext(t, map[string]string{
+			"account": "123456789012",
+			"car":     "AdminRole",
+		})
+		err := cmd.ValidateCmdRun(ctx)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("nil favorites with favorite flag fails gracefully", func(t *testing.T) {
+		cmd := &Cmd{
+			config: &structs.Configuration{
+				Favorites: nil,
+			},
+		}
+
+		ctx := newTestContext(t, map[string]string{
+			"favorite": "my-fav",
+		})
+		err := cmd.ValidateCmdRun(ctx)
+
+		if err == nil {
+			t.Error("expected error but got nil")
+		} else if err.Error() != "can't find favorite" {
+			t.Errorf("error = %q, want %q", err.Error(), "can't find favorite")
+		}
+	})
+}

--- a/lib/kion/kion_test.go
+++ b/lib/kion/kion_test.go
@@ -1,0 +1,71 @@
+package kion
+
+import "testing"
+
+func TestConvertAccessType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// API to CLI format
+		{"console_access to web", "console_access", "web"},
+		{"short_term_key_access to cli", "short_term_key_access", "cli"},
+
+		// CLI to API format
+		{"web to console_access", "web", "console_access"},
+		{"cli to short_term_key_access", "cli", "short_term_key_access"},
+
+		// Passthrough for unknown values
+		{"empty string passthrough", "", ""},
+		{"unknown value passthrough", "unknown", "unknown"},
+		{"random string passthrough", "something_else", "something_else"},
+
+		// Case sensitivity - function is case-sensitive, these should passthrough
+		{"uppercase WEB passthrough", "WEB", "WEB"},
+		{"uppercase CLI passthrough", "CLI", "CLI"},
+		{"mixed case Web passthrough", "Web", "Web"},
+		{"uppercase CONSOLE_ACCESS passthrough", "CONSOLE_ACCESS", "CONSOLE_ACCESS"},
+
+		// Whitespace - function does not trim, these should passthrough
+		{"leading space passthrough", " web", " web"},
+		{"trailing space passthrough", "web ", "web "},
+		{"space padded passthrough", " cli ", " cli "},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ConvertAccessType(test.input)
+			if got != test.want {
+				t.Errorf("ConvertAccessType(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestConvertAccessType_Bidirectional(t *testing.T) {
+	// Test that conversions are properly bidirectional
+	pairs := []struct {
+		apiFormat string
+		cliFormat string
+	}{
+		{"console_access", "web"},
+		{"short_term_key_access", "cli"},
+	}
+
+	for _, pair := range pairs {
+		t.Run("api_to_cli_"+pair.apiFormat, func(t *testing.T) {
+			got := ConvertAccessType(pair.apiFormat)
+			if got != pair.cliFormat {
+				t.Errorf("ConvertAccessType(%q) = %q, want %q", pair.apiFormat, got, pair.cliFormat)
+			}
+		})
+
+		t.Run("cli_to_api_"+pair.cliFormat, func(t *testing.T) {
+			got := ConvertAccessType(pair.cliFormat)
+			if got != pair.apiFormat {
+				t.Errorf("ConvertAccessType(%q) = %q, want %q", pair.cliFormat, got, pair.apiFormat)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fix ValidateCmdRun to properly support --account/--alias + --car without requiring --favorite flag

- Add comprehensive test coverage for:
  - kion.ConvertAccessType() with case sensitivity and whitespace edge cases
  - cache.NullCache with table-driven tests and zero-value scenarios
  - commands validators with nil favorites and region behavior tests