### PR TITLE
Add screen reader mode for accessible CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Notes for upgrading...
 
 ### Added
 
+- Screen reader mode (`--screen-reader` flag, `KION_SCREEN_READER` env var, `kion.screen_reader_mode` config key) replaces TUI widgets and Unicode symbols with plain numbered lists and ASCII text for compatibility with screen readers and assistive technology
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ __Global Options:__
 
 --quiet                                Reduces output for certain functions.
 
+--screen-reader                        Enables screen reader mode. Replaces TUI
+                                       widgets (interactive selectors, pipe bars)
+                                       and Unicode symbols with plain numbered
+                                       lists and ASCII text for compatibility with
+                                       screen readers and assistive technology.
+
 --profile PROFILE                      Use the specified PROFILE from the Kion CLI
                                        configuration file. If no profile is specified
                                        the default will be used.
@@ -409,6 +415,9 @@ KION_DEBUG               "TRUE" to enable verbose debugging of the Kion CLI.
 
 KION_QUIET               "TRUE" to reduce messages for quieter operation.
 
+KION_SCREEN_READER       "TRUE" to enable screen reader mode. Replaces TUI
+                         widgets and Unicode symbols with plain text output.
+
 The following are maintained for compatibility with older Kion utilities:
 
 CTKEY_USERNAME           Maps to KION_USERNAME.
@@ -435,6 +444,9 @@ kion.saml_print_url                  Set 'true' to print the authentication url 
                                      Defaults to 'false'.
 kion.disable_cache                   Prevents Kion CLI from caching STAK if 'true', defaults
                                      to 'false'.
+kion.screen_reader_mode              Enables screen reader mode if 'true'. Replaces TUI
+                                     widgets and Unicode symbols with plain text output.
+                                     Defaults to 'false'.
 kion.default_region                  The CSP region to use if one is not provided by argument
                                      flag or environment variable.
 

--- a/doc/man1/kion.1
+++ b/doc/man1/kion.1
@@ -44,6 +44,8 @@ Disable the use of cache for Kion CLI.
 Enable debug mode for additional CLI output.
 .It --quiet
 Enable quiet mode for to reduce unnecessary output.
+.It --screen-reader
+Enable screen reader mode. Replaces TUI widgets (interactive selectors, pipe bars) and Unicode symbols with plain numbered lists and ASCII text for compatibility with screen readers and assistive technology.
 .It --profile PROFILE
 Use the specified PROFILE from the Kion CLI configuration file.
 .It --help, -h
@@ -170,6 +172,8 @@ The Kion IDMS issuer value.
 "TRUE" to enable verbose debugging of the Kion CLI.
 .It KION_QUIET
 "TRUE" to reduce messages for quieter operation.
+.It KION_SCREEN_READER
+"TRUE" to enable screen reader mode. Replaces TUI widgets and Unicode symbols with plain text output.
 .El
 
 .Sh FILES

--- a/lib/commands/commands.go
+++ b/lib/commands/commands.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/99designs/keyring"
+	fatihcolor "github.com/fatih/color"
 	"github.com/hashicorp/go-version"
 	"github.com/kionsoftware/kion-cli/lib/cache"
 	"github.com/kionsoftware/kion-cli/lib/helper"
@@ -184,6 +185,7 @@ func (c *Cmd) handleProfile(profileName string, cCtx *cli.Context) error {
 		var disableCacheFlagged bool
 		var debugFlagged bool
 		var quietFlagged bool
+		var screenReaderFlagged bool
 
 		setGlobalFlags := cCtx.FlagNames()
 		for _, flag := range setGlobalFlags {
@@ -209,6 +211,8 @@ func (c *Cmd) handleProfile(profileName string, cCtx *cli.Context) error {
 				debugFlagged = true
 			case "quiet":
 				quietFlagged = true
+			case "screen-reader":
+				screenReaderFlagged = true
 			}
 		}
 
@@ -239,6 +243,9 @@ func (c *Cmd) handleProfile(profileName string, cCtx *cli.Context) error {
 		if quietFlagged {
 			c.config.Kion.QuietMode = true
 		}
+		if screenReaderFlagged {
+			c.config.Kion.ScreenReaderMode = true
+		}
 	}
 	return nil
 }
@@ -263,6 +270,14 @@ func (c *Cmd) BeforeCommands(cCtx *cli.Context) error {
 	err := c.handleProfile(profileName, cCtx)
 	if err != nil {
 		return err
+	}
+
+	// propagate screen reader mode to the helper package so all prompts
+	// use plain text I/O instead of TUI widgets; also disable ANSI color
+	// so fatih/color calls throughout commands emit plain text
+	if c.config.Kion.ScreenReaderMode {
+		helper.ScreenReaderMode = true
+		fatihcolor.NoColor = true
 	}
 
 	// grab the Kion url if not already set

--- a/lib/commands/utility.go
+++ b/lib/commands/utility.go
@@ -26,11 +26,19 @@ func (c *Cmd) deleteUpstreamFavorites(favorites []structs.Favorite) error {
 		fmt.Printf(" removing upstream favorite %s: ", f.Name)
 		_, err := kion.DeleteFavorite(c.config.Kion.URL, c.config.Kion.APIKey, f.Name)
 		if err != nil {
-			color.Red("x %s\n", err)
+			if c.config.Kion.ScreenReaderMode {
+				fmt.Printf("[FAIL] %s\n", err)
+			} else {
+				color.Red("x %s\n", err)
+			}
 			hasErrors = true
 			continue
 		}
-		color.Green("✓")
+		if c.config.Kion.ScreenReaderMode {
+			fmt.Println("[OK]")
+		} else {
+			color.Green("✓")
+		}
 	}
 	if hasErrors {
 		return errors.New("one or more favorites failed to delete")
@@ -48,11 +56,19 @@ func (c *Cmd) createUpstreamFavorite(favorites []structs.Favorite) error {
 		f.AccessType = kion.ConvertAccessType(f.AccessType)
 		_, _, err := kion.CreateFavorite(c.config.Kion.URL, c.config.Kion.APIKey, f)
 		if err != nil {
-			color.Red("x %s\n", err)
+			if c.config.Kion.ScreenReaderMode {
+				fmt.Printf("[FAIL] %s\n", err)
+			} else {
+				color.Red("x %s\n", err)
+			}
 			hasErrors = true
 			continue
 		}
-		color.Green("✓")
+		if c.config.Kion.ScreenReaderMode {
+			fmt.Println("[OK]")
+		} else {
+			color.Green("✓")
+		}
 	}
 	if hasErrors {
 		return errors.New("one or more errors occurred during the creation process")

--- a/lib/commands/validators.go
+++ b/lib/commands/validators.go
@@ -28,9 +28,9 @@ type validationContext struct {
 }
 
 // newValidationContext creates a new validation context.
-func newValidationContext() *validationContext {
+func newValidationContext(screenReader bool) *validationContext {
 	return &validationContext{
-		styles: styles.NewOutputStyles(),
+		styles: styles.NewOutputStyles(screenReader),
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -358,7 +358,7 @@ func (c *Cmd) checkSSOURLReachability(ctx *validationContext, metadata *samlType
 
 // ValidateSAML validates SAML configuration and connectivity.
 func (c *Cmd) ValidateSAML(cCtx *cli.Context) error {
-	ctx := newValidationContext()
+	ctx := newValidationContext(c.config.Kion.ScreenReaderMode)
 
 	// Header
 	fmt.Println()
@@ -400,7 +400,7 @@ func (c *Cmd) ValidateSAML(cCtx *cli.Context) error {
 	fmt.Println(ctx.styles.RenderSeparator())
 	if ctx.allPassed {
 		var summary strings.Builder
-		summary.WriteString("✓ All validation checks passed!\n\n")
+		summary.WriteString(ctx.styles.PassStr() + " All validation checks passed!\n\n")
 		summary.WriteString("Your SAML configuration appears to be correct.\n")
 		summary.WriteString("Try running SAML authentication to complete the flow.")
 
@@ -415,7 +415,7 @@ func (c *Cmd) ValidateSAML(cCtx *cli.Context) error {
 	}
 
 	var summary strings.Builder
-	summary.WriteString("✗ Some validation checks failed.\n\n")
+	summary.WriteString(ctx.styles.FailStr() + " Some validation checks failed.\n\n")
 	summary.WriteString("Please review the errors above and fix the configuration.")
 
 	failBox := ctx.styles.SummaryBox.BorderForeground(ctx.styles.XMark.GetForeground())

--- a/lib/defaults/defaults.yml
+++ b/lib/defaults/defaults.yml
@@ -33,3 +33,4 @@ kion:
   disable_cache: false
   debug_mode: false
   quiet_mode: false
+  screen_reader_mode: false

--- a/lib/helper/prompts.go
+++ b/lib/helper/prompts.go
@@ -1,11 +1,7 @@
 package helper
 
 import (
-	"bufio"
-	"fmt"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/kionsoftware/kion-cli/lib/styles"
@@ -18,17 +14,13 @@ import (
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-// ScreenReaderMode disables all TUI widgets (huh forms, lipgloss colours,
-// box-drawing characters) and falls back to plain text I/O.  Set this before
-// any prompt is called; typically done in BeforeCommands after profile
-// resolution so that --screen-reader and the config-file value are both
+// ScreenReaderMode switches all huh forms to WithAccessible(true), which
+// replaces TUI widgets (pipe bar, arrow-key navigation, screen redraw) with
+// sequential plain-text prompts that screen readers can follow linearly.
+// Set this before any prompt is called; typically done in BeforeCommands after
+// profile resolution so --screen-reader and the config-file value are both
 // honoured.
 var ScreenReaderMode bool
-
-// stdinReader is a shared reader for plain-text prompt fallbacks.
-// A single instance is required so that multiple sequential reads
-// do not each buffer ahead and silently discard each other's input.
-var stdinReader = bufio.NewReader(os.Stdin)
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //
@@ -59,41 +51,26 @@ func shouldLimitHeight(optionCount int) (bool, int) {
 	return false, 0
 }
 
+// newForm wraps huh.NewForm and applies WithAccessible when ScreenReaderMode
+// is on, so callers don't need to repeat the check.
+func newForm(groups ...*huh.Group) *huh.Form {
+	return huh.NewForm(groups...).
+		WithTheme(styles.FormTheme).
+		WithAccessible(ScreenReaderMode)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //
 //  Prompts                                                                   //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-// PromptSelect prompts the user to select from a slice of options.  It
+// PromptSelect prompts the user to select from a slice of options. It
 // requires that the selection made be one of the options provided.
 //
-// In screen reader mode the TUI is replaced with a numbered list printed to
-// stdout; the user types the corresponding number and presses Enter.
+// In screen reader mode huh switches to a numbered list printed sequentially
+// to stdout; the user types the number and presses Enter.
 func PromptSelect(message string, description string, options []string) (string, error) {
-	if ScreenReaderMode {
-		fmt.Println(message)
-		if description != "" {
-			fmt.Println(description)
-		}
-		for i, opt := range options {
-			fmt.Printf("  %d. %s\n", i+1, opt)
-		}
-		for {
-			fmt.Printf("Enter number (1-%d): ", len(options))
-			line, err := stdinReader.ReadString('\n')
-			if err != nil {
-				return "", err
-			}
-			num, err := strconv.Atoi(strings.TrimSpace(line))
-			if err != nil || num < 1 || num > len(options) {
-				fmt.Printf("Invalid selection. Please enter a number between 1 and %d.\n", len(options))
-				continue
-			}
-			return options[num-1], nil
-		}
-	}
-
 	var selection string
 
 	// Convert to huh options
@@ -108,16 +85,12 @@ func PromptSelect(message string, description string, options []string) (string,
 		Options(huhOptions...).
 		Value(&selection)
 
-	// Apply height limiting only if needed
+	// Apply height limiting only if needed (no-op in accessible mode)
 	if shouldLimit, height := shouldLimitHeight(len(options)); shouldLimit {
 		selectField = selectField.Height(height)
 	}
 
-	form := huh.NewForm(
-		huh.NewGroup(selectField),
-	).WithTheme(styles.FormTheme)
-
-	if err := form.Run(); err != nil {
+	if err := newForm(huh.NewGroup(selectField)).Run(); err != nil {
 		return "", err
 	}
 
@@ -126,34 +99,19 @@ func PromptSelect(message string, description string, options []string) (string,
 
 // PromptInput prompts the user to provide dynamic input.
 //
-// In screen reader mode the TUI is replaced with a plain text prompt written
-// to stdout; the user types their answer and presses Enter.
+// In screen reader mode huh prints the title and reads a plain line from
+// stdin with no TUI decoration.
 func PromptInput(message string) (string, error) {
-	if ScreenReaderMode {
-		fmt.Print(message + " ")
-		line, err := stdinReader.ReadString('\n')
-		if err != nil {
-			return "", err
-		}
-		input := strings.TrimSpace(line)
-		if input == "" {
-			return "", fmt.Errorf("input is required")
-		}
-		return input, nil
-	}
-
 	var input string
 
-	form := huh.NewForm(
+	if err := newForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title(message).
 				Value(&input).
 				Validate(styles.RequiredValidator),
 		),
-	).WithTheme(styles.FormTheme)
-
-	if err := form.Run(); err != nil {
+	).Run(); err != nil {
 		return "", err
 	}
 
@@ -162,26 +120,12 @@ func PromptInput(message string) (string, error) {
 
 // PromptPassword prompts the user to provide sensitive dynamic input.
 //
-// In screen reader mode the TUI is replaced with a plain prompt written to
-// stdout; input is read without echo using term.ReadPassword so the password
-// is never displayed on screen.
+// In screen reader mode huh prints the title and reads from stdin without
+// echoing characters.
 func PromptPassword(message string) (string, error) {
-	if ScreenReaderMode {
-		fmt.Print(message + " ")
-		password, err := term.ReadPassword(int(os.Stdin.Fd()))
-		fmt.Println() // move to next line after hidden input
-		if err != nil {
-			return "", err
-		}
-		if len(password) == 0 {
-			return "", fmt.Errorf("password is required")
-		}
-		return string(password), nil
-	}
-
 	var input string
 
-	form := huh.NewForm(
+	if err := newForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title(message).
@@ -189,9 +133,7 @@ func PromptPassword(message string) (string, error) {
 				Value(&input).
 				Validate(styles.RequiredValidator),
 		),
-	).WithTheme(styles.FormTheme)
-
-	if err := form.Run(); err != nil {
+	).Run(); err != nil {
 		return "", err
 	}
 

--- a/lib/helper/prompts.go
+++ b/lib/helper/prompts.go
@@ -1,12 +1,34 @@
 package helper
 
 import (
+	"bufio"
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/kionsoftware/kion-cli/lib/styles"
 	"golang.org/x/term"
 )
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Screen Reader Mode                                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// ScreenReaderMode disables all TUI widgets (huh forms, lipgloss colours,
+// box-drawing characters) and falls back to plain text I/O.  Set this before
+// any prompt is called; typically done in BeforeCommands after profile
+// resolution so that --screen-reader and the config-file value are both
+// honoured.
+var ScreenReaderMode bool
+
+// stdinReader is a shared reader for plain-text prompt fallbacks.
+// A single instance is required so that multiple sequential reads
+// do not each buffer ahead and silently discard each other's input.
+var stdinReader = bufio.NewReader(os.Stdin)
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //
@@ -43,9 +65,35 @@ func shouldLimitHeight(optionCount int) (bool, int) {
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-// PromptSelect prompts the user to select from a slice of options. It
+// PromptSelect prompts the user to select from a slice of options.  It
 // requires that the selection made be one of the options provided.
+//
+// In screen reader mode the TUI is replaced with a numbered list printed to
+// stdout; the user types the corresponding number and presses Enter.
 func PromptSelect(message string, description string, options []string) (string, error) {
+	if ScreenReaderMode {
+		fmt.Println(message)
+		if description != "" {
+			fmt.Println(description)
+		}
+		for i, opt := range options {
+			fmt.Printf("  %d. %s\n", i+1, opt)
+		}
+		for {
+			fmt.Printf("Enter number (1-%d): ", len(options))
+			line, err := stdinReader.ReadString('\n')
+			if err != nil {
+				return "", err
+			}
+			num, err := strconv.Atoi(strings.TrimSpace(line))
+			if err != nil || num < 1 || num > len(options) {
+				fmt.Printf("Invalid selection. Please enter a number between 1 and %d.\n", len(options))
+				continue
+			}
+			return options[num-1], nil
+		}
+	}
+
 	var selection string
 
 	// Convert to huh options
@@ -77,7 +125,23 @@ func PromptSelect(message string, description string, options []string) (string,
 }
 
 // PromptInput prompts the user to provide dynamic input.
+//
+// In screen reader mode the TUI is replaced with a plain text prompt written
+// to stdout; the user types their answer and presses Enter.
 func PromptInput(message string) (string, error) {
+	if ScreenReaderMode {
+		fmt.Print(message + " ")
+		line, err := stdinReader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		input := strings.TrimSpace(line)
+		if input == "" {
+			return "", fmt.Errorf("input is required")
+		}
+		return input, nil
+	}
+
 	var input string
 
 	form := huh.NewForm(
@@ -97,7 +161,24 @@ func PromptInput(message string) (string, error) {
 }
 
 // PromptPassword prompts the user to provide sensitive dynamic input.
+//
+// In screen reader mode the TUI is replaced with a plain prompt written to
+// stdout; input is read without echo using term.ReadPassword so the password
+// is never displayed on screen.
 func PromptPassword(message string) (string, error) {
+	if ScreenReaderMode {
+		fmt.Print(message + " ")
+		password, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println() // move to next line after hidden input
+		if err != nil {
+			return "", err
+		}
+		if len(password) == 0 {
+			return "", fmt.Errorf("password is required")
+		}
+		return string(password), nil
+	}
+
 	var input string
 
 	form := huh.NewForm(

--- a/lib/structs/configuration-structs.go
+++ b/lib/structs/configuration-structs.go
@@ -30,6 +30,7 @@ type Kion struct {
 	DefaultRegion    string `yaml:"default_region,omitempty"`
 	DebugMode        bool   `yaml:"debug_mode,omitempty"`
 	QuietMode        bool   `yaml:"quiet_mode,omitempty"`
+	ScreenReaderMode bool   `yaml:"screen_reader_mode,omitempty"`
 }
 
 // Favorite holds information about user defined favorites used to quickly

--- a/lib/styles/output.go
+++ b/lib/styles/output.go
@@ -2,6 +2,7 @@ package styles
 
 import (
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"golang.org/x/term"
@@ -40,10 +41,36 @@ type OutputStyles struct {
 	// Layout dimensions
 	TerminalWidth   int
 	CheckLabelWidth int
+
+	// Accessibility
+	ScreenReader bool
 }
 
 // NewOutputStyles creates a new set of output styles with terminal-aware dimensions.
-func NewOutputStyles() *OutputStyles {
+// When screenReader is true, all styling is replaced with plain ASCII text so that
+// screen readers receive clean, unambiguous output.
+func NewOutputStyles(screenReader bool) *OutputStyles {
+	if screenReader {
+		return &OutputStyles{
+			CheckMark:       lipgloss.NewStyle(),
+			XMark:           lipgloss.NewStyle(),
+			CheckLabel:      lipgloss.NewStyle(),
+			ErrorText:       lipgloss.NewStyle().PaddingLeft(2),
+			WarningText:     lipgloss.NewStyle().PaddingLeft(2),
+			InfoText:        lipgloss.NewStyle().PaddingLeft(2),
+			DetailText:      lipgloss.NewStyle().PaddingLeft(2),
+			SuccessText:     lipgloss.NewStyle(),
+			MainHeader:      lipgloss.NewStyle(),
+			SectionHeader:   lipgloss.NewStyle(),
+			Separator:       lipgloss.NewStyle(),
+			DetailsBox:      lipgloss.NewStyle(),
+			SummaryBox:      lipgloss.NewStyle(),
+			TerminalWidth:   80,
+			CheckLabelWidth: 78,
+			ScreenReader:    true,
+		}
+	}
+
 	// Detect terminal width
 	termWidth := 80 // Default fallback
 	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && width > 0 {
@@ -142,7 +169,14 @@ func NewOutputStyles() *OutputStyles {
 ////////////////////////////////////////////////////////////////////////////////
 
 // RenderCheck renders a check result with label and status indicator.
+// In screen reader mode it uses "[PASS]" / "[FAIL]" instead of Unicode symbols.
 func (s *OutputStyles) RenderCheck(label string, passed bool) string {
+	if s.ScreenReader {
+		if passed {
+			return "[PASS] " + label
+		}
+		return "[FAIL] " + label
+	}
 	status := s.CheckMark.Render("✓")
 	if !passed {
 		status = s.XMark.Render("✗")
@@ -150,7 +184,7 @@ func (s *OutputStyles) RenderCheck(label string, passed bool) string {
 	return s.CheckLabel.Render(label) + " " + status
 }
 
-// RenderDetail renders a detail line (indented gray text).
+// RenderDetail renders a detail line (indented text).
 func (s *OutputStyles) RenderDetail(text string) string {
 	return s.DetailText.Render(text)
 }
@@ -176,12 +210,13 @@ func (s *OutputStyles) RenderNote(text string) string {
 }
 
 // RenderSeparator renders a horizontal separator line.
+// In screen reader mode it uses plain hyphens instead of box-drawing characters.
 func (s *OutputStyles) RenderSeparator() string {
-	width := s.CheckLabelWidth + 2
-	line := ""
-	for range width {
-		line += "─"
+	if s.ScreenReader {
+		return "---"
 	}
+	width := s.CheckLabelWidth + 2
+	line := strings.Repeat("─", width)
 	return s.Separator.Render(line)
 }
 
@@ -193,4 +228,22 @@ func (s *OutputStyles) RenderMainHeader(text string) string {
 // RenderSectionHeader renders a section header.
 func (s *OutputStyles) RenderSectionHeader(text string) string {
 	return s.SectionHeader.Render(text)
+}
+
+// PassStr returns the appropriate pass symbol for embedding in strings.
+// In screen reader mode returns "[PASS]"; otherwise returns "✓".
+func (s *OutputStyles) PassStr() string {
+	if s.ScreenReader {
+		return "[PASS]"
+	}
+	return "✓"
+}
+
+// FailStr returns the appropriate fail symbol for embedding in strings.
+// In screen reader mode returns "[FAIL]"; otherwise returns "✗".
+func (s *OutputStyles) FailStr() string {
+	if s.ScreenReader {
+		return "[FAIL]"
+	}
+	return "✗"
 }

--- a/lib/styles/output_test.go
+++ b/lib/styles/output_test.go
@@ -1,0 +1,110 @@
+package styles
+
+import (
+	"strings"
+	"testing"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  OutputStyles Tests                                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// TestNewOutputStylesScreenReader verifies that screen reader mode produces
+// plain ASCII output free of Unicode symbols and ANSI colour codes.
+func TestNewOutputStylesScreenReader(t *testing.T) {
+	s := NewOutputStyles(true)
+
+	if !s.ScreenReader {
+		t.Error("ScreenReader field should be true")
+	}
+}
+
+func TestRenderCheckScreenReader(t *testing.T) {
+	s := NewOutputStyles(true)
+
+	pass := s.RenderCheck("Configuration valid", true)
+	if !strings.HasPrefix(pass, "[PASS]") {
+		t.Errorf("expected pass result to start with [PASS], got: %q", pass)
+	}
+	if strings.Contains(pass, "✓") {
+		t.Errorf("screen reader mode must not emit ✓, got: %q", pass)
+	}
+
+	fail := s.RenderCheck("Configuration valid", false)
+	if !strings.HasPrefix(fail, "[FAIL]") {
+		t.Errorf("expected fail result to start with [FAIL], got: %q", fail)
+	}
+	if strings.Contains(fail, "✗") {
+		t.Errorf("screen reader mode must not emit ✗, got: %q", fail)
+	}
+}
+
+func TestRenderCheckNormal(t *testing.T) {
+	s := NewOutputStyles(false)
+
+	pass := s.RenderCheck("Configuration valid", true)
+	if !strings.Contains(pass, "✓") {
+		t.Errorf("normal mode should contain ✓, got: %q", pass)
+	}
+
+	fail := s.RenderCheck("Configuration valid", false)
+	if !strings.Contains(fail, "✗") {
+		t.Errorf("normal mode should contain ✗, got: %q", fail)
+	}
+}
+
+func TestRenderSeparatorScreenReader(t *testing.T) {
+	s := NewOutputStyles(true)
+
+	sep := s.RenderSeparator()
+	if strings.Contains(sep, "─") {
+		t.Errorf("screen reader mode must not emit box-drawing characters, got: %q", sep)
+	}
+	if sep != "---" {
+		t.Errorf("expected separator to be \"---\", got: %q", sep)
+	}
+}
+
+func TestPassStrFailStr(t *testing.T) {
+	sr := NewOutputStyles(true)
+	if sr.PassStr() != "[PASS]" {
+		t.Errorf("screen reader PassStr should be [PASS], got: %q", sr.PassStr())
+	}
+	if sr.FailStr() != "[FAIL]" {
+		t.Errorf("screen reader FailStr should be [FAIL], got: %q", sr.FailStr())
+	}
+
+	normal := NewOutputStyles(false)
+	if normal.PassStr() != "✓" {
+		t.Errorf("normal PassStr should be ✓, got: %q", normal.PassStr())
+	}
+	if normal.FailStr() != "✗" {
+		t.Errorf("normal FailStr should be ✗, got: %q", normal.FailStr())
+	}
+}
+
+func TestRenderMessagesScreenReader(t *testing.T) {
+	s := NewOutputStyles(true)
+
+	tests := []struct {
+		name   string
+		got    string
+		prefix string
+	}{
+		{"RenderError", s.RenderError("something broke"), "Error:"},
+		{"RenderWarning", s.RenderWarning("watch out"), "Warning:"},
+		{"RenderFix", s.RenderFix("do this instead"), "Fix:"},
+		{"RenderNote", s.RenderNote("for your info"), "Note:"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trimmed := strings.TrimSpace(tt.got)
+			if !strings.HasPrefix(trimmed, tt.prefix) {
+				t.Errorf("expected output to start with %q, got: %q", tt.prefix, trimmed)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -59,6 +59,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Enable screen reader mode early (from config file or env var) so that
+	// any output before BeforeCommands runs is also plain text.  The flag
+	// destination below keeps them in sync for flag-based activation.
+	if config.Kion.ScreenReaderMode || os.Getenv("KION_SCREEN_READER") == "true" {
+		color.NoColor = true
+		helper.ScreenReaderMode = true
+	}
+
 	// prep default text for password
 	passwordDefaultText := ""
 	if config.Kion.Password != "" {
@@ -195,6 +203,13 @@ func main() {
 				EnvVars:     []string{"KION_QUIET"},
 				Usage:       "enable quiet mode to reduce output",
 				Destination: &config.Kion.QuietMode,
+			},
+			&cli.BoolFlag{
+				Name:        "screen-reader",
+				Value:       config.Kion.ScreenReaderMode,
+				EnvVars:     []string{"KION_SCREEN_READER"},
+				Usage:       "enable screen reader mode: replaces TUI widgets and Unicode symbols with plain text",
+				Destination: &config.Kion.ScreenReaderMode,
 			},
 		},
 


### PR DESCRIPTION
## Summary

- Adds `--screen-reader` global flag (also `KION_SCREEN_READER` env var and `kion.screen_reader_mode` config key) that makes the CLI fully compatible with screen readers and assistive technology
- When active, replaces `huh` TUI widgets (interactive selector with pipe bar, arrow-key navigation, full-screen redraws) with `huh`'s built-in accessible mode: plain numbered lists printed sequentially to stdout, user types a number and presses Enter
- When active, replaces Unicode symbols (`✓` `✗` `─` box borders) with `[PASS]` / `[FAIL]` / `---` and borderless output
- When active, disables ANSI colour so all output is plain text
- Normal mode is completely unchanged

## Details

Flag precedence follows the established config SOP (Flag > Env var > Config file > Default):

```
kion --screen-reader stak
KION_SCREEN_READER=true kion stak
# or persistently in ~/.kion.yml:
kion:
  screen_reader_mode: true
```

Note: as a global flag, `--screen-reader` must come before the subcommand.

All interactive paths are covered: account/CAR selection wizard (`stak`, `console`), favorites selector, authentication method selection, username/password/API key prompts, and `util push-favorites` confirmation flow.

## Test plan

- [ ] `kion --screen-reader stak` — numbered account/role selection, no TUI
- [ ] `kion --screen-reader fav` — numbered favorites list, no TUI
- [ ] `kion --screen-reader util validate-saml` — `[PASS]`/`[FAIL]` output, no box borders
- [ ] `KION_SCREEN_READER=true kion stak` — env var activation works
- [ ] `screen_reader_mode: true` in `~/.kion.yml` — config file activation works
- [ ] `--screen-reader` with `--profile` — mode preserved after profile switch
- [ ] Normal mode unchanged — existing TUI behaviour unaffected when flag is absent
- [ ] `go test ./...` — all 31 tests pass