### PR TITLE
Dedupe repeated CAR rows in selection prompts

### DIFF
--- a/lib/helper/transform.go
+++ b/lib/helper/transform.go
@@ -87,12 +87,17 @@ func MapAccountsFromCARS(cars []kion.CAR, pid uint) ([]string, map[string]string
 }
 
 // MapCAR transforms a slice of CARs into a slice of their names and a map
-// indexed by their names.
+// indexed by their names. Note that the v3/me/cloud-access-role endpoint can
+// return the same CAR and account pairing more than once (observed with CARs
+// assigned directly to users) so duplicates are skipped.
 func MapCAR(cars []kion.CAR) ([]string, map[string]kion.CAR) {
 	var cNames []string
 	cMap := make(map[string]kion.CAR)
 	for _, car := range cars {
 		name := fmt.Sprintf("%v (%v)", car.Name, car.ID)
+		if slices.Contains(cNames, name) {
+			continue
+		}
 		cNames = append(cNames, name)
 		cMap[name] = car
 	}

--- a/lib/helper/transform_test.go
+++ b/lib/helper/transform_test.go
@@ -113,6 +113,16 @@ func TestMapCAR(t *testing.T) {
 				fmt.Sprintf("%v (%v)", kionTestCARsNames[5], kionTestCARs[5].ID): kionTestCARs[5],
 			},
 		},
+		{
+			"Duplicates",
+			[]kion.CAR{kionTestCARs[0], kionTestCARs[0], kionTestCARs[0]},
+			[]string{
+				fmt.Sprintf("%v (%v)", kionTestCARsNames[0], kionTestCARs[0].ID),
+			},
+			map[string]kion.CAR{
+				fmt.Sprintf("%v (%v)", kionTestCARsNames[0], kionTestCARs[0].ID): kionTestCARs[0],
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What

The Cloud Access Role selection prompt (`stak`/`console` wizard) can show the same CAR multiple times. `GET /v3/me/cloud-access-role` sometimes returns the same CAR + account pairing more than once — we observe it consistently returning **three identical rows** (byte-identical JSON, same CAR id, same account) for project-local CARs assigned directly to users via `user_ids`, on a current Kion release. Group-assigned CARs return once. `MapCAR` appends prompt rows unconditionally, so the picker renders each repeat:

```
Choose a Cloud Access Role:
  ▸ Esc-EngineerProdAdmin-ben (13)
    Esc-EngineerProdAdmin-ben (13)
    Esc-EngineerProdAdmin-ben (13)
```

## Fix

Skip rows whose display name (`name (id)`) is already present, mirroring the dedupe `MapAccountsFromCARS` already does for account names. Since the id is part of the display name (#24), distinct CARs are never collapsed; only literal repeats are. The lookup map already collapsed duplicates (last write wins on the same key), so selection behavior is unchanged — this only removes the repeated rows from the prompt.

Added a `Duplicates` case to `TestMapCAR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)