### PR TITLE
Hint at existing favs instead of duplicate config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist/
 .vectorcode/
 .claude/
 CLAUDE.md
+doc/*.local.md

--- a/lib/commands/console.go
+++ b/lib/commands/console.go
@@ -63,9 +63,15 @@ func (c *Cmd) FedConsole(cCtx *cli.Context) error {
 	// grab the second argument, used as a redirect parameter
 	redirect := getSecondArgument(cCtx)
 
-	// print out how to store as a favorite
+	// print out how to store as a favorite (or that one already exists)
 	if !c.config.Kion.QuietMode {
-		if err := helper.PrintFavoriteConfig(os.Stdout, car, "", "web"); err != nil {
+		favorites, ferr := c.getFavorites(cCtx)
+		if ferr != nil {
+			// non-fatal: just skip the existing-favorite hint
+			favorites = nil
+		}
+		existing := helper.MatchExistingFavorite(favorites, car, "web")
+		if err := helper.PrintFavoriteConfig(os.Stdout, car, "", "web", existing); err != nil {
 			return err
 		}
 	}

--- a/lib/commands/console.go
+++ b/lib/commands/console.go
@@ -65,14 +65,14 @@ func (c *Cmd) FedConsole(cCtx *cli.Context) error {
 
 	// print out how to store as a favorite (or that one already exists)
 	if !c.config.Kion.QuietMode {
+		// non-fatal: if we cannot determine the user's favorites we stay quiet
+		// rather than suggest they create one that may already exist
 		favorites, ferr := c.getFavorites(cCtx)
-		if ferr != nil {
-			// non-fatal: just skip the existing-favorite hint
-			favorites = nil
-		}
-		existing := helper.MatchExistingFavorite(favorites, car, "web")
-		if err := helper.PrintFavoriteConfig(os.Stdout, car, "", "web", existing); err != nil {
-			return err
+		if ferr == nil {
+			existing := helper.MatchExistingFavorite(favorites, car, "web")
+			if err := helper.PrintFavoriteConfig(os.Stdout, car, "", "web", existing); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lib/commands/stak.go
+++ b/lib/commands/stak.go
@@ -112,14 +112,14 @@ func (c *Cmd) GenStaks(cCtx *cli.Context) error {
 		return helper.SaveAWSCreds(stak, car)
 	case "subshell":
 		if !c.config.Kion.QuietMode {
+			// non-fatal: if we cannot determine the user's favorites we stay
+			// quiet rather than suggest they create one that may already exist
 			favorites, ferr := c.getFavorites(cCtx)
-			if ferr != nil {
-				// non-fatal: just skip the existing-favorite hint
-				favorites = nil
-			}
-			existing := helper.MatchExistingFavorite(favorites, car, "cli")
-			if err := helper.PrintFavoriteConfig(os.Stdout, car, region, "cli", existing); err != nil {
-				return err
+			if ferr == nil {
+				existing := helper.MatchExistingFavorite(favorites, car, "cli")
+				if err := helper.PrintFavoriteConfig(os.Stdout, car, region, "cli", existing); err != nil {
+					return err
+				}
 			}
 		}
 		var displayAlais string

--- a/lib/commands/stak.go
+++ b/lib/commands/stak.go
@@ -112,7 +112,13 @@ func (c *Cmd) GenStaks(cCtx *cli.Context) error {
 		return helper.SaveAWSCreds(stak, car)
 	case "subshell":
 		if !c.config.Kion.QuietMode {
-			if err := helper.PrintFavoriteConfig(os.Stdout, car, region, "cli"); err != nil {
+			favorites, ferr := c.getFavorites(cCtx)
+			if ferr != nil {
+				// non-fatal: just skip the existing-favorite hint
+				favorites = nil
+			}
+			existing := helper.MatchExistingFavorite(favorites, car, "cli")
+			if err := helper.PrintFavoriteConfig(os.Stdout, car, region, "cli", existing); err != nil {
 				return err
 			}
 		}

--- a/lib/helper/output.go
+++ b/lib/helper/output.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/kionsoftware/kion-cli/lib/kion"
+	"github.com/kionsoftware/kion-cli/lib/structs"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,9 +45,40 @@ func PrintSTAK(w io.Writer, stak kion.STAK, region string) error {
 	return nil
 }
 
-// PrintFavoriteConfig prints out how to save the current selection as a
-// favorite within the users configuration file.
-func PrintFavoriteConfig(w io.Writer, car kion.CAR, region string, access_type string) error {
+// MatchExistingFavorite returns the favorite that best matches the given
+// account/CAR/access_type combination, or nil if none match. A favorite with
+// no access_type set is considered generic and matches any access type, but
+// an exact access_type match is preferred.
+func MatchExistingFavorite(favorites []structs.Favorite, car kion.CAR, accessType string) *structs.Favorite {
+	var generic *structs.Favorite
+	for i, f := range favorites {
+		if f.Account != car.AccountNumber || f.CAR != car.Name {
+			continue
+		}
+		if f.AccessType == accessType {
+			return &favorites[i]
+		}
+		if f.AccessType == "" && generic == nil {
+			generic = &favorites[i]
+		}
+	}
+	return generic
+}
+
+// PrintFavoriteConfig prints either a hint that the current selection is
+// already stored as a favorite (and how to use it), or — if no matching
+// favorite is found — a config snippet for the user to add one.
+func PrintFavoriteConfig(w io.Writer, car kion.CAR, region string, access_type string, existing *structs.Favorite) error {
+	if existing != nil {
+		color.New(color.FgBlue).Fprintf(w, "\nYou already have a favorite for this selection. Next time you can run:\n")
+		flag := ""
+		if access_type == "web" && existing.AccessType != "web" {
+			flag = " --web"
+		}
+		color.New(color.FgGreen).Fprintf(w, "  kion favorite%v %v\n\n", flag, existing.Name)
+		return nil
+	}
+
 	color.New(color.FgBlue).Fprintf(w, "\nTo save your selection as a favorite add the following to\nyour configuration file under the 'favorites:' section:\n")
 	fmt.Fprintf(w, "  - name: ")
 	color.New(color.FgGreen).Fprintf(w, "[your favorite alias]\n")

--- a/lib/helper/output.go
+++ b/lib/helper/output.go
@@ -45,6 +45,12 @@ func PrintSTAK(w io.Writer, stak kion.STAK, region string) error {
 	return nil
 }
 
+// Access types used to distinguish web console access from CLI credentials.
+const (
+	AccessTypeWeb = "web"
+	AccessTypeCLI = "cli"
+)
+
 // MatchExistingFavorite returns the favorite that best matches the given
 // account/CAR/access_type combination, or nil if none match. A favorite with
 // no access_type set is considered generic and matches any access type, but
@@ -72,7 +78,7 @@ func PrintFavoriteConfig(w io.Writer, car kion.CAR, region string, access_type s
 	if existing != nil {
 		color.New(color.FgBlue).Fprintf(w, "\nYou already have a favorite for this selection. Next time you can run:\n")
 		flag := ""
-		if access_type == "web" && existing.AccessType != "web" {
+		if access_type == AccessTypeWeb && existing.AccessType != AccessTypeWeb {
 			flag = " --web"
 		}
 		color.New(color.FgGreen).Fprintf(w, "  kion favorite%v %v\n\n", flag, existing.Name)

--- a/lib/helper/output_test.go
+++ b/lib/helper/output_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/kionsoftware/kion-cli/lib/kion"
+	"github.com/kionsoftware/kion-cli/lib/structs"
 )
 
 func TestPrintSTAK(t *testing.T) {
@@ -148,6 +150,188 @@ func TestPrintCredentialProcess(t *testing.T) {
 
 			if buf.String() != expected {
 				t.Fatalf("Expected %s, but got %s", expected, buf.String())
+			}
+		})
+	}
+}
+
+const (
+	testAccessTypeWeb = AccessTypeWeb
+	testAccessTypeCLI = AccessTypeCLI
+	testCARName       = "some-car"
+	testAccountNum    = "111111111111"
+)
+
+func TestMatchExistingFavorite(t *testing.T) {
+	car := kion.CAR{AccountNumber: testAccountNum, Name: testCARName}
+
+	tests := []struct {
+		description string
+		favorites   []structs.Favorite
+		accessType  string
+		want        string
+	}{
+		{
+			"Nil Favorites",
+			nil,
+			testAccessTypeCLI,
+			"",
+		},
+		{
+			"Empty Favorites",
+			[]structs.Favorite{},
+			testAccessTypeCLI,
+			"",
+		},
+		{
+			"Exact Access Type Match",
+			[]structs.Favorite{
+				{Name: "web-fav", Account: testAccountNum, CAR: testCARName, AccessType: testAccessTypeWeb},
+			},
+			testAccessTypeWeb,
+			"web-fav",
+		},
+		{
+			"Generic Favorite Matches Any Access Type",
+			[]structs.Favorite{
+				{Name: "generic-fav", Account: testAccountNum, CAR: testCARName, AccessType: ""},
+			},
+			testAccessTypeWeb,
+			"generic-fav",
+		},
+		{
+			"Exact Match Preferred Over Generic",
+			[]structs.Favorite{
+				{Name: "generic-fav", Account: testAccountNum, CAR: testCARName, AccessType: ""},
+				{Name: "web-fav", Account: testAccountNum, CAR: testCARName, AccessType: testAccessTypeWeb},
+			},
+			testAccessTypeWeb,
+			"web-fav",
+		},
+		{
+			"Exact Match Preferred Regardless Of Order",
+			[]structs.Favorite{
+				{Name: "web-fav", Account: testAccountNum, CAR: testCARName, AccessType: testAccessTypeWeb},
+				{Name: "generic-fav", Account: testAccountNum, CAR: testCARName, AccessType: ""},
+			},
+			testAccessTypeWeb,
+			"web-fav",
+		},
+		{
+			"First Generic Wins",
+			[]structs.Favorite{
+				{Name: "generic-one", Account: testAccountNum, CAR: testCARName, AccessType: ""},
+				{Name: "generic-two", Account: testAccountNum, CAR: testCARName, AccessType: ""},
+			},
+			testAccessTypeCLI,
+			"generic-one",
+		},
+		{
+			"Mismatched Access Type Only",
+			[]structs.Favorite{
+				{Name: "web-fav", Account: testAccountNum, CAR: testCARName, AccessType: testAccessTypeWeb},
+			},
+			testAccessTypeCLI,
+			"",
+		},
+		{
+			"Mismatched Account",
+			[]structs.Favorite{
+				{Name: "other-acct", Account: "222222222222", CAR: testCARName, AccessType: testAccessTypeCLI},
+			},
+			testAccessTypeCLI,
+			"",
+		},
+		{
+			"Mismatched CAR",
+			[]structs.Favorite{
+				{Name: "other-car", Account: testAccountNum, CAR: "other-car", AccessType: testAccessTypeCLI},
+			},
+			testAccessTypeCLI,
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got := MatchExistingFavorite(test.favorites, car, test.accessType)
+			if test.want == "" {
+				if got != nil {
+					t.Errorf("\ngot:\n  %v\nwanted:\n  no match", got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("\ngot:\n  no match\nwanted:\n  %v", test.want)
+			}
+			if got.Name != test.want {
+				t.Errorf("\ngot:\n  %v\nwanted:\n  %v", got.Name, test.want)
+			}
+		})
+	}
+}
+
+func TestPrintFavoriteConfig(t *testing.T) {
+	// pin color output off so assertions do not depend on tty detection
+	origNoColor := color.NoColor
+	color.NoColor = true
+	defer func() { color.NoColor = origNoColor }()
+
+	car := kion.CAR{AccountNumber: testAccountNum, Name: testCARName}
+
+	tests := []struct {
+		description string
+		region      string
+		accessType  string
+		existing    *structs.Favorite
+		want        string
+	}{
+		{
+			"No Match Prints Snippet Without Region",
+			"",
+			testAccessTypeWeb,
+			nil,
+			"\nTo save your selection as a favorite add the following to\nyour configuration file under the 'favorites:' section:\n  - name: [your favorite alias]\n    account: 111111111111\n    cloud_access_role: some-car\n    access_type: web\n\n",
+		},
+		{
+			"No Match Prints Snippet With Region",
+			"us-gov-west-1",
+			testAccessTypeCLI,
+			nil,
+			"\nTo save your selection as a favorite add the following to\nyour configuration file under the 'favorites:' section:\n  - name: [your favorite alias]\n    account: 111111111111\n    cloud_access_role: some-car\n    region: us-gov-west-1\n    access_type: cli\n\n",
+		},
+		{
+			"Existing Exact Web Favorite Omits Flag",
+			"",
+			testAccessTypeWeb,
+			&structs.Favorite{Name: "web-fav", AccessType: testAccessTypeWeb},
+			"\nYou already have a favorite for this selection. Next time you can run:\n  kion favorite web-fav\n\n",
+		},
+		{
+			"Existing Generic Favorite Adds Web Flag",
+			"",
+			testAccessTypeWeb,
+			&structs.Favorite{Name: "generic-fav", AccessType: ""},
+			"\nYou already have a favorite for this selection. Next time you can run:\n  kion favorite --web generic-fav\n\n",
+		},
+		{
+			"Existing Generic Favorite For Cli Omits Flag",
+			"us-gov-west-1",
+			testAccessTypeCLI,
+			&structs.Favorite{Name: "generic-fav", AccessType: ""},
+			"\nYou already have a favorite for this selection. Next time you can run:\n  kion favorite generic-fav\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			var output bytes.Buffer
+			err := PrintFavoriteConfig(&output, car, test.region, test.accessType, test.existing)
+			if err != nil {
+				t.Error(err)
+			}
+			if output.String() != test.want {
+				t.Errorf("\ngot:\n  %q\nwanted:\n  %q", output.String(), test.want)
 			}
 		})
 	}


### PR DESCRIPTION
When printing the "save as favorite" helper after a stak or console run, check the user's combined favorites (config + API) for one that already matches the selected account, cloud access role, and access type. If found, print the command to use it rather than a config snippet the user does not need.

MatchExistingFavorite prefers an exact access_type match and falls back to a favorite with no access_type set, which Favorites treats as CLI access. In that generic case the console path appends --web to the suggested command so the hint federates into the browser rather than dropping the user into a subshell.

Failure to retrieve favorites is non-fatal and falls back to the existing config snippet.